### PR TITLE
Field reordering

### DIFF
--- a/bin/lib/plan-messages.js
+++ b/bin/lib/plan-messages.js
@@ -42,6 +42,7 @@ const renderChunk = (chunk, errors) => {
     if (firstChange.type === 'field/create') {
       message.push(chalk`\n  {bold Create field {yellow ${firstChange.payload.fieldId}}}`);
     }
+
     if (firstChange.type === 'field/update') {
       message.push(chalk`\n  {bold Update field {yellow ${firstChange.payload.fieldId}}}`);
     }
@@ -52,6 +53,29 @@ const renderChunk = (chunk, errors) => {
           const value = JSON.stringify(fieldChange.payload.props[key]);
           message.push(chalk`    - {italic ${key}:} ${value}`);
         }
+      }
+
+      if (fieldChange.type === 'field/move') {
+        const movement = fieldChange.payload.movement;
+        let humanizedMovement;
+
+        if (movement.direction === 'toTheTop') {
+          humanizedMovement = `to the first position`;
+        }
+
+        if (movement.direction === 'toTheBottom') {
+          humanizedMovement = `to the last position`;
+        }
+
+        if (movement.direction === 'afterField') {
+          humanizedMovement = chalk`after field {yellow ${movement.pivot}}`;
+        }
+
+        if (movement.direction === 'beforeField') {
+          humanizedMovement = chalk`before field {yellow ${movement.pivot}}`;
+        }
+
+        message.push(chalk`  {bold Move field {yellow ${fieldChange.payload.fieldId}} ${humanizedMovement}}`);
       }
     }
   }

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -27,6 +27,39 @@ Whenever setting a value to a property which is not matching the expected type.
 field.name(true)
 ```
 
+## INVALID_MOVEMENT_TYPE
+Whenever trying to move a field with the wrong type for the field id.
+
+ Example:
+```javascript
+contentType.moveField(3).toTheTop()
+```
+
+## INVALID_MOVEMENT_WITH_SELF
+Whenever trying to move a field relative to itself.
+
+ Example:
+```javascript
+contentType.moveField('name').afterField('name')
+```
+
+## INVALID_MOVEMENT_NAME
+Whenever trying to move a field relative to another with an invalid movement.
+
+ Example:
+```javascript
+contentType.moveField('name').xyz('surname')
+```
+
+## INVALID_MOVEMENT_NAME_WITH_SUGGESTION
+Whenever trying to move a field relative to another with an invalid movement but we can provide a suggestion.
+
+ Example:
+```javascript
+contentType.moveField('name').after('surname')
+```
+
+
 While evaluating your migration script we validate that the actions you want to perform on content types and fields aren't wrong in any sense.
 These validations are bound to the entity type and action on which they ocurred. Therefore the error keys are scoped to it
 and have a layout of `{entity}.{action}.{validation name}`.
@@ -59,6 +92,48 @@ Whenever trying to edit a field which doesn't exist.
 contentType.createField('name')
 // ...
 contentType.editField('nmae')
+```
+
+## field.move.FIELD_DELETED
+Whenever trying to move a field which was already deleted.
+
+ Example:
+```javascript
+contentType.deleteField('name')
+// ...
+contentType.moveField('name').toTheTop()
+```
+
+## field.move.FIELD_DOES_NOT_EXIST
+Whenever trying to move a field which doesn't exists.
+
+# field.move.FIELD_ALREADY_MOVED
+Whenever trying to move a field which was already moved.
+
+ Example:
+```javascript
+contentType.moveField('name').toTheTop()
+contentType.moveField('name').toTheBottom()
+```
+
+## field.move.CONTENT_TYPE_DOES_NOT_EXIST
+Whenever you try to move a field on a non existing content type.
+
+## field.move.PIVOT_FIELD_DOES_NOT_EXIST
+Whenever you try to move field relative to another one which doesn't exist.
+
+ Example:
+```javascript
+contentType.moveField('name').afterField('somefield-that-doesnt-exist')
+```
+
+## field.move.PIVOT_FIELD_DELETED
+Whenever you try to move a field relative to another one which has been already deleted.
+
+ Example:
+```javascript
+contentType.deleteField('surname')
+contentType.moveField('name').afterField('surname')
 ```
 
 ## contentType.create.CONTENT_TYPE_ALREADY_CREATED

--- a/examples/08-move-field.js
+++ b/examples/08-move-field.js
@@ -1,0 +1,30 @@
+// Example of setting the `displayField` of a content type.
+module.exports = function (migration) {
+  const food = migration.editContentType('food');
+
+  food.createField('calories')
+    .type('Number')
+    .name('How many calories does it have?');
+
+  food.createField('sugar')
+    .type('Number')
+    .name('Amount of sugar');
+
+  food.createField('vegan')
+    .type('Boolean')
+    .name('Vegan friendly');
+
+  food.createField('producer')
+    .type('Symbol')
+    .name('Food producer');
+
+  food.createField('gmo')
+    .type('Boolean')
+    .name('Genetically modified food');
+
+  food.moveField('calories').toTheTop();
+  food.moveField('sugar').toTheBottom();
+  food.moveField('producer').beforeField('vegan');
+  food.moveField('gmo').afterField('vegan');
+};
+

--- a/lib/migration-chunks/validation/errors.js
+++ b/lib/migration-chunks/validation/errors.js
@@ -31,6 +31,26 @@ module.exports = {
       CONTENT_TYPE_DOES_NOT_EXIST: (id, ctId) => {
         return `You cannot set a property on field with id "${id}" on content type "${ctId}" because it does not exist.`;
       }
+    },
+    move: {
+      FIELD_DELETED: (id) => {
+        return `You cannot move the field with id "${id}" because it has already been deleted.`;
+      },
+      FIELD_DOES_NOT_EXIST: (id) => {
+        return `You cannot move the field with id "${id}" because it does not exist.`;
+      },
+      FIELD_ALREADY_MOVED: (id) => {
+        return `You cannot move the field with id "${id}" more than once per migration.`;
+      },
+      CONTENT_TYPE_DOES_NOT_EXIST: (id, ctId) => {
+        return `You cannot move a field on content type "${ctId}" because it does not exist.`;
+      },
+      PIVOT_FIELD_DOES_NOT_EXIST: (id, direction) => {
+        return `You cannot move a field ${direction} the field "${id}" because it doesn't exist`;
+      },
+      PIVOT_FIELD_DELETED: (id, direction) => {
+        return `You cannot move a field ${direction} the field "${id}" because it has been already deleted`;
+      }
     }
   },
   contentType: {

--- a/lib/migration-chunks/validation/field.js
+++ b/lib/migration-chunks/validation/field.js
@@ -10,6 +10,152 @@ const invalidActionError = (message, step) => {
   };
 };
 
+const RELATIVE_MOVEMENTS = ['afterField', 'beforeField'];
+
+function fieldId (step) {
+  return step.payload.fieldId;
+}
+
+function pivotId (step) {
+  return step.payload.movement.pivot;
+}
+
+function contentTypeId (step) {
+  return step.payload.contentTypeId;
+}
+
+function fieldMovementKey (step) {
+  return [contentTypeId(step), fieldId(step)].join('/');
+}
+
+function fieldExists (validationContext, fieldId) {
+  return validationContext.fieldSet.has(fieldId);
+}
+
+function fieldHasBeenRemoved (validationContext, fieldId) {
+  return validationContext.fieldRemovals.has(fieldId);
+}
+
+function fieldHasBeenMoved (validationContext, movementKey) {
+  return validationContext.fieldMovements.has(movementKey);
+}
+
+const checks = {
+  'field/create': (errors, step, validationContext) => {
+    const id = fieldId(step);
+    const exists = fieldExists(validationContext, id);
+
+    if (!exists) {
+      validationContext.fieldSet.add(id);
+      validationContext.fieldRemovals.delete(id);
+    }
+
+    if (exists) {
+      errors.push(invalidActionError(
+        fieldErrors.create.FIELD_ALREADY_CREATED(id),
+        step
+      ));
+    }
+  },
+
+  'field/update': (errors, step, validationContext) => {
+    const id = fieldId(step);
+    const exists = fieldExists(validationContext, id);
+    const removed = fieldHasBeenRemoved(validationContext, id);
+
+    if (!exists && removed) {
+      errors.push(invalidActionError(
+        fieldErrors.update.FIELD_ALREADY_DELETED(id),
+        step
+      ));
+    }
+
+    if (!exists && !removed) {
+      errors.push(invalidActionError(
+        fieldErrors.update.FIELD_DOES_NOT_EXIST(id),
+        step
+      ));
+    }
+  },
+
+  'field/delete': (errors, step, validationContext) => {
+    const id = fieldId(step);
+    const exists = fieldExists(validationContext, id);
+    const removed = fieldHasBeenRemoved(validationContext, id);
+
+    if (exists) {
+      validationContext.fieldSet.delete(id);
+      validationContext.fieldRemovals.add(id);
+    }
+
+    if (!exists && removed) {
+      errors.push(invalidActionError(
+        fieldErrors.delete.FIELD_ALREADY_DELETED(id),
+        step
+      ));
+    }
+
+    if (!exists && !removed) {
+      errors.push(invalidActionError(
+        fieldErrors.delete.FIELD_DOES_NOT_EXIST(id),
+        step
+      ));
+    }
+  },
+
+  'field/move': (errors, step, validationContext) => {
+    const id = fieldId(step);
+    const pivot = pivotId(step);
+    const exists = fieldExists(validationContext, id);
+    const removed = fieldHasBeenRemoved(validationContext, id);
+    const moved = fieldHasBeenMoved(validationContext, fieldMovementKey(step));
+    const isRelativeMovement = RELATIVE_MOVEMENTS.includes(step.payload.movement.direction);
+
+    validationContext.fieldMovements.add(fieldMovementKey(step));
+
+    if (isRelativeMovement) {
+      const pivotExists = fieldExists(validationContext, pivot);
+      const pivotRemoved = fieldHasBeenRemoved(validationContext, pivot);
+      const direction = step.payload.movement.direction === 'afterField' ? 'after' : 'before';
+
+      if (!pivotExists && !pivotRemoved) {
+        errors.push(invalidActionError(
+          fieldErrors.move.PIVOT_FIELD_DOES_NOT_EXIST(step.payload.movement.pivot, direction),
+          step
+        ));
+      }
+
+      if (!pivotExists && pivotRemoved) {
+        errors.push(invalidActionError(
+          fieldErrors.move.PIVOT_FIELD_DELETED(step.payload.movement.pivot, direction),
+          step
+        ));
+      }
+    }
+
+    if (!exists && removed) {
+      errors.push(invalidActionError(
+        fieldErrors.move.FIELD_DELETED(id),
+        step
+      ));
+    }
+
+    if (!exists && !removed) {
+      errors.push(invalidActionError(
+        fieldErrors.move.FIELD_DOES_NOT_EXIST(id),
+        step
+      ));
+    }
+
+    if (moved) {
+      errors.push(invalidActionError(
+        fieldErrors.move.FIELD_ALREADY_MOVED(id),
+        step
+      ));
+    }
+  }
+};
+
 module.exports = function (chunks, contentTypes = []) {
   const errors = [];
   const contentTypeFields = contentTypes.reduce((acc, curr) => {
@@ -19,30 +165,22 @@ module.exports = function (chunks, contentTypes = []) {
   }, {});
 
   const recentlyRemoved = {};
+  const recentlyMoved = {};
 
   for (const chunk of chunks) {
     const contentTypeId = chunk[0].payload.contentTypeId;
     const contentTypeExists = Boolean(contentTypes.find((ct) => ct.sys.id === contentTypeId));
     const fieldSet = contentTypeFields[contentTypeId] || new Set();
     const fieldRemovals = recentlyRemoved[contentTypeId] || new Set();
+    const fieldMovements = recentlyMoved[contentTypeId] || new Set();
+
+    const validationContext = { fieldSet, fieldRemovals, fieldMovements };
 
     // ...
     const fieldSteps = chunk.filter((step) => step.type.startsWith('field'));
 
     for (const step of fieldSteps) {
       const fieldId = step.payload.fieldId;
-      const fieldExists = fieldSet.has(fieldId);
-      const fieldRecentlyRemoved = fieldRemovals.has(fieldId);
-
-      if (step.type === 'field/create' && !fieldExists) {
-        fieldSet.add(fieldId);
-        fieldRemovals.delete(fieldId);
-      }
-
-      if (step.type === 'field/delete' && fieldExists) {
-        fieldSet.delete(fieldId);
-        fieldRemovals.add(fieldId);
-      }
 
       if (!contentTypeExists) {
         const type = step.type.split('/')[1];
@@ -53,45 +191,12 @@ module.exports = function (chunks, contentTypes = []) {
         continue;
       }
 
-      if (step.type === 'field/create' && fieldExists) {
-        errors.push(invalidActionError(
-          fieldErrors.create.FIELD_ALREADY_CREATED(fieldId),
-          step
-        ));
-      }
-
-
-      if (step.type === 'field/delete' && !fieldExists && fieldRecentlyRemoved) {
-        errors.push(invalidActionError(
-          fieldErrors.delete.FIELD_ALREADY_DELETED(fieldId),
-          step
-        ));
-      }
-
-      if (step.type === 'field/delete' && !fieldExists && !fieldRecentlyRemoved) {
-        errors.push(invalidActionError(
-          fieldErrors.delete.FIELD_DOES_NOT_EXIST(fieldId),
-          step
-        ));
-      }
-
-      if (step.type === 'field/update' && !fieldExists && fieldRecentlyRemoved) {
-        errors.push(invalidActionError(
-          fieldErrors.update.FIELD_ALREADY_DELETED(fieldId),
-          step
-        ));
-      }
-
-      if (step.type === 'field/update' && !fieldExists && !fieldRecentlyRemoved) {
-        errors.push(invalidActionError(
-          fieldErrors.update.FIELD_DOES_NOT_EXIST(fieldId),
-          step
-        ));
-      }
+      checks[step.type](errors, step, validationContext);
     }
 
     contentTypeFields[contentTypeId] = fieldSet;
     recentlyRemoved[contentTypeId] = fieldRemovals;
+    recentlyMoved[contentTypeId] = fieldMovements;
   }
 
   return errors;

--- a/lib/migration-payloads/index.js
+++ b/lib/migration-payloads/index.js
@@ -26,6 +26,30 @@ function buildFields (result, actions) {
 
       Object.assign(source, props);
     }
+
+    if (action.type === 'field/move') {
+      const field = _.find(result.payload.fields, { id });
+      _.pull(result.payload.fields, field);
+
+      if (action.payload.movement.direction === 'toTheTop') {
+        result.payload.fields.unshift(field);
+      }
+
+      if (action.payload.movement.direction === 'toTheBottom') {
+        result.payload.fields.push(field);
+      }
+
+      const pivot = action.payload.movement.pivot;
+      const pivotIndex = _.findIndex(result.payload.fields, { id: pivot });
+
+      if (action.payload.movement.direction === 'afterField') {
+        result.payload.fields.splice(pivotIndex + 1, 0, field);
+      }
+
+      if (action.payload.movement.direction === 'beforeField') {
+        result.payload.fields.splice(pivotIndex, 0, field);
+      }
+    }
   });
 }
 

--- a/lib/migration-steps/action-creators.js
+++ b/lib/migration-steps/action-creators.js
@@ -64,6 +64,22 @@ const actionCreators = {
         }
       }
     }),
+    move: (contentTypeId, contentTypeInstanceId, fieldId, fieldInstanceId, callsite, movement) => ({
+      type: 'field/move',
+      meta: {
+        contentTypeInstanceId: `contentType/${contentTypeId}/${contentTypeInstanceId}`,
+        fieldInstanceId: `fields/${fieldId}/${fieldInstanceId}`,
+        callsite: {
+          file: callsite.getFileName(),
+          line: callsite.getLineNumber()
+        }
+      },
+      payload: {
+        contentTypeId,
+        fieldId,
+        movement
+      }
+    }),
     delete: (contentTypeId, contentTypeInstanceId, fieldId, fieldInstanceId, callsite) => ({
       type: 'field/delete',
       meta: {

--- a/lib/migration-steps/errors.js
+++ b/lib/migration-steps/errors.js
@@ -9,6 +9,18 @@ const errors = {
   },
   INVALID_PROPERTY_TYPE: (propName, typeName, actualType, expectedType) => {
     return `"${actualType}" is not a valid type for the ${typeName} property "${propName}". Expected "${expectedType}".`;
+  },
+  INVALID_MOVEMENT_TYPE: (typeName) => {
+    return `"${typeName}" is not a valid type for field movement. Expected "string".`;
+  },
+  INVALID_MOVEMENT_WITH_SELF: (fieldId) => {
+    return `You cannot move the field "${fieldId}" relative to itself.`;
+  },
+  INVALID_MOVEMENT_NAME: (movement) => {
+    return `"${movement}" is not a valid field movement.`;
+  },
+  INVALID_MOVEMENT_NAME_WITH_SUGGESTION: (movement, suggestion) => {
+    return `${errors.INVALID_MOVEMENT_NAME(movement)} Did you mean "${suggestion}"?`;
   }
 };
 

--- a/lib/migration-steps/index.js
+++ b/lib/migration-steps/index.js
@@ -26,6 +26,8 @@ const createInstanceIdManager = () => {
   };
 };
 
+class Movement extends DispatchProxy {}
+
 class Field extends DispatchProxy {
   constructor (id, props = {}, { dispatchUpdate }) {
     super({ dispatchUpdate });
@@ -84,6 +86,30 @@ class ContentType extends DispatchProxy {
     });
 
     return field;
+  }
+
+  moveField (id) {
+    const fieldInstanceId = this.fieldInstanceIds.getNew(id);
+
+    const contentTypeId = this.id;
+    const contentTypeInstanceId = this.instanceId;
+
+    const movement = new Movement({
+      dispatchUpdate: (callsite, property, value) => {
+        const action = actionCreators.field.move(
+          contentTypeId,
+          contentTypeInstanceId,
+          id,
+          fieldInstanceId,
+          callsite,
+          { direction: property, pivot: value }
+        );
+
+        this.dispatch(action);
+      }
+    });
+
+    return movement;
   }
 
   deleteField (id) {

--- a/lib/migration-steps/validation.js
+++ b/lib/migration-steps/validation.js
@@ -30,10 +30,9 @@ const fieldPropsValidations = {
 const getStepErrors = function ({ displayName, validations }, step) {
   const errors = [];
   const propNames = Object.keys(step.payload.props);
+  const validProps = Object.keys(validations);
 
   for (const propName of propNames) {
-    const validProps = Object.keys(validations);
-
     if (!validProps.includes(propName)) {
       let message;
 
@@ -81,6 +80,64 @@ const getFieldErrors = getStepErrors.bind(null, {
   validations: fieldPropsValidations
 });
 
+const fieldMovementValidations = {
+  toTheTop: Joi.any(),
+  toTheBottom: Joi.any(),
+  afterField: Joi.string().required(),
+  beforeField: Joi.string().required()
+};
+
+const getFieldMovementErrors = function (step) {
+  const validMoves = Object.keys(fieldMovementValidations);
+  const movement = step.payload.movement.direction;
+
+  if (validMoves.includes(movement)) {
+    const pivot = step.payload.movement.pivot;
+    const schema = fieldMovementValidations[movement];
+    const { error } = Joi.validate(pivot, schema);
+    const pivotType = kindOf(pivot);
+    const sourceFieldId = step.payload.fieldId;
+
+    if (error) {
+      return [
+        {
+          type: 'InvalidType',
+          message: validationErrors.INVALID_MOVEMENT_TYPE(pivotType),
+          details: { step }
+        }
+      ];
+    }
+
+    if (sourceFieldId === pivot) {
+      return [
+        {
+          type: 'InvalidMovement',
+          message: validationErrors.INVALID_MOVEMENT_WITH_SELF(sourceFieldId),
+          details: { step }
+        }
+      ];
+    }
+
+    return [];
+  }
+
+  const suggestion = didYouMean(movement, validMoves);
+
+  let message = validationErrors.INVALID_MOVEMENT_NAME(movement);
+
+  if (suggestion) {
+    message = validationErrors.INVALID_MOVEMENT_NAME_WITH_SUGGESTION(movement, suggestion);
+  }
+
+  return [
+    {
+      type: 'InvalidMovement',
+      message,
+      details: { step }
+    }
+  ];
+};
+
 const getValidationErrors = function (steps) {
   let errors = [];
 
@@ -91,6 +148,10 @@ const getValidationErrors = function (steps) {
 
     if (step.type === 'field/update') {
       errors = errors.concat(getFieldErrors(step));
+    }
+
+    if (step.type === 'field/move') {
+      errors = errors.concat(getFieldMovementErrors(step));
     }
   }
 

--- a/test/unit/lib/migration-chunks/validation/field/move.spec.js
+++ b/test/unit/lib/migration-chunks/validation/field/move.spec.js
@@ -1,0 +1,358 @@
+'use strict';
+
+const { expect } = require('chai');
+const Bluebird = require('bluebird');
+
+const migrationPlan = require('../../../../../../lib/migration-chunks');
+const migrationSteps = require('../../../../../../lib/migration-steps');
+const validatePlan = require('../../../../../../lib/migration-chunks/validation');
+const stripCallsite = require('../../../../../helpers/strip-callsite');
+const stripCallsites = (plan) => plan.map((chunk) => chunk.map(stripCallsite));
+
+describe('field movement plan validation', function () {
+  describe('when moving a field that does not exist', function () {
+    it('returns an error', Bluebird.coroutine(function * () {
+      const steps = yield migrationSteps(function up (migration) {
+        const person = migration.createContentType('person', {
+          description: 'A content type for a person',
+          name: 'foo'
+        });
+
+        person.moveField('name').toTheTop();
+      });
+
+      const contentTypes = [];
+
+      const plan = stripCallsites(migrationPlan(steps));
+      const errors = validatePlan(plan, contentTypes);
+
+      expect(errors).to.eql([
+        {
+          type: 'InvalidAction',
+          message: 'You cannot move the field with id "name" because it does not exist.',
+          details: {
+            step: {
+              'type': 'field/move',
+              'meta': {
+                'contentTypeInstanceId': 'contentType/person/0',
+                'fieldInstanceId': 'fields/name/0'
+              },
+              'payload': {
+                'contentTypeId': 'person',
+                'fieldId': 'name',
+                'movement': {
+                  'direction': 'toTheTop',
+                  'pivot': undefined
+                }
+              }
+            }
+          }
+        }
+      ]);
+    }));
+  });
+
+  describe('when moving a field that was deleted', function () {
+    it('returns an error', Bluebird.coroutine(function * () {
+      const steps = yield migrationSteps(function up (migration) {
+        const person = migration.createContentType('person', {
+          description: 'A content type for a person',
+          name: 'foo'
+        });
+
+        person.createField('name').type('Symbol');
+        person.deleteField('name');
+        person.moveField('name').toTheTop();
+      });
+
+      const contentTypes = [];
+
+      const plan = stripCallsites(migrationPlan(steps));
+      const errors = validatePlan(plan, contentTypes);
+
+      expect(errors).to.eql([
+        {
+          type: 'InvalidAction',
+          message: 'You cannot move the field with id "name" because it has already been deleted.',
+          details: {
+            step: {
+              'type': 'field/move',
+              'meta': {
+                'contentTypeInstanceId': 'contentType/person/0',
+                'fieldInstanceId': 'fields/name/2'
+              },
+              'payload': {
+                'contentTypeId': 'person',
+                'fieldId': 'name',
+                'movement': {
+                  'direction': 'toTheTop',
+                  'pivot': undefined
+                }
+              }
+            }
+          }
+        }
+      ]);
+    }));
+  });
+
+  describe('when moving a field multiple times', function () {
+    it('returns all the validation errors', Bluebird.coroutine(function * () {
+      const steps = yield migrationSteps(function up (migration) {
+        const person = migration.createContentType('person', {
+          description: 'A content type for a person',
+          name: 'Person'
+        });
+
+        person.createField('fullName', {
+          name: 'Full Name',
+          type: 'Symbol'
+        });
+
+        person.moveField('fullName').toTheTop();
+        person.moveField('fullName').toTheTop();
+      });
+
+
+      const contentTypes = [];
+
+      const plan = stripCallsites(migrationPlan(steps));
+      const errors = validatePlan(plan, contentTypes);
+
+      expect(errors).to.eql([
+        {
+          type: 'InvalidAction',
+          message: 'You cannot move the field with id "fullName" more than once per migration.',
+          details: {
+            step: {
+              'type': 'field/move',
+              'meta': {
+                'contentTypeInstanceId': 'contentType/person/0',
+                'fieldInstanceId': 'fields/fullName/2'
+              },
+              'payload': {
+                'contentTypeId': 'person',
+                'fieldId': 'fullName',
+                'movement': {
+                  'direction': 'toTheTop',
+                  'pivot': undefined
+                }
+              }
+            }
+          }
+        }
+      ]);
+    }));
+  });
+
+  describe('when moving a field multiple times in different chunks', function () {
+    it('returns all the validation errors', Bluebird.coroutine(function * () {
+      const steps = yield migrationSteps(function up (migration) {
+        const person = migration.createContentType('person', {
+          description: 'A content type for a person',
+          name: 'Person'
+        });
+
+        person.createField('fullName', {
+          name: 'Full Name',
+          type: 'Symbol'
+        });
+
+        person.moveField('fullName').toTheTop();
+
+        const dog = migration.createContentType('dog', {
+          description: 'A content type for a dog',
+          name: 'Dog'
+        });
+
+        dog.createField('age', {
+          name: 'age',
+          type: 'Number'
+        });
+
+        person.moveField('fullName').toTheBottom();
+      });
+
+
+      const contentTypes = [];
+
+      const plan = stripCallsites(migrationPlan(steps));
+      const errors = validatePlan(plan, contentTypes);
+
+      expect(errors).to.eql([
+        {
+          type: 'InvalidAction',
+          message: 'You cannot move the field with id "fullName" more than once per migration.',
+          details: {
+            step: {
+              'type': 'field/move',
+              'meta': {
+                'contentTypeInstanceId': 'contentType/person/0',
+                'fieldInstanceId': 'fields/fullName/2'
+              },
+              'payload': {
+                'contentTypeId': 'person',
+                'fieldId': 'fullName',
+                'movement': {
+                  'direction': 'toTheBottom',
+                  'pivot': undefined
+                }
+              }
+            }
+          }
+        }
+      ]);
+    }));
+  });
+
+  describe('whe moving a field in a non existing Content Type', function () {
+    it('returns all validation errors', Bluebird.coroutine(function * () {
+      const steps = yield migrationSteps(function up (migration) {
+        const person = migration.editContentType('person');
+
+        person.moveField('fullName').toTheTop();
+      });
+
+
+      const contentTypes = [];
+
+      const plan = stripCallsites(migrationPlan(steps));
+      const errors = validatePlan(plan, contentTypes);
+
+      expect(errors).to.eql([
+        {
+          type: 'InvalidAction',
+          message: 'You cannot move a field on content type "person" because it does not exist.',
+          details: {
+            step: {
+              'type': 'field/move',
+              'meta': {
+                'contentTypeInstanceId': 'contentType/person/0',
+                'fieldInstanceId': 'fields/fullName/0'
+              },
+              'payload': {
+                'contentTypeId': 'person',
+                'fieldId': 'fullName',
+                'movement': {
+                  'direction': 'toTheTop',
+                  'pivot': undefined
+                }
+              }
+            }
+          }
+        }
+      ]);
+    }));
+  });
+
+  describe('when moving a field relative to a non existing field', function () {
+    it('returns all validation errors', Bluebird.coroutine(function * () {
+      const steps = yield migrationSteps(function up (migration) {
+        const person = migration.createContentType('person');
+
+        person.createField('fullName').type('Symbol').name('Full name');
+        person.moveField('fullName').afterField('i-do-not-exist');
+
+        person.createField('age').type('Number').name('Full name');
+        person.moveField('age').beforeField('i-do-not-exist');
+      });
+
+
+      const contentTypes = [];
+
+      const plan = stripCallsites(migrationPlan(steps));
+      const errors = validatePlan(plan, contentTypes);
+
+      expect(errors).to.eql([
+        {
+          type: 'InvalidAction',
+          message: 'You cannot move a field after the field "i-do-not-exist" because it doesn\'t exist',
+          details: {
+            step: {
+              'type': 'field/move',
+              'meta': {
+                'contentTypeInstanceId': 'contentType/person/0',
+                'fieldInstanceId': 'fields/fullName/1'
+              },
+              'payload': {
+                'contentTypeId': 'person',
+                'fieldId': 'fullName',
+                'movement': {
+                  'direction': 'afterField',
+                  'pivot': 'i-do-not-exist'
+                }
+              }
+            }
+          }
+        },
+        {
+          type: 'InvalidAction',
+          message: 'You cannot move a field before the field "i-do-not-exist" because it doesn\'t exist',
+          details: {
+            step: {
+              'type': 'field/move',
+              'meta': {
+                'contentTypeInstanceId': 'contentType/person/0',
+                'fieldInstanceId': 'fields/age/1'
+              },
+              'payload': {
+                'contentTypeId': 'person',
+                'fieldId': 'age',
+                'movement': {
+                  'direction': 'beforeField',
+                  'pivot': 'i-do-not-exist'
+                }
+              }
+            }
+          }
+        }
+      ]);
+    }));
+  });
+
+  describe('when moving a field relative to a removed field', function () {
+    it('returns all validation errors', Bluebird.coroutine(function * () {
+      const steps = yield migrationSteps(function up (migration) {
+        const person = migration.createContentType('person');
+
+        person.createField('fullName').type('Symbol').name('Full name');
+
+        person.deleteField('fullName');
+
+        person.createField('age').type('Number').name('Full name');
+        person.moveField('age').beforeField('fullName');
+      });
+
+
+      const contentTypes = [];
+
+      const plan = stripCallsites(migrationPlan(steps));
+      const errors = validatePlan(plan, contentTypes);
+
+      expect(errors).to.eql([
+        {
+          type: 'InvalidAction',
+          message: 'You cannot move a field before the field "fullName" because it has been already deleted',
+          details: {
+            step: {
+              'type': 'field/move',
+              'meta': {
+                'contentTypeInstanceId': 'contentType/person/0',
+                'fieldInstanceId': 'fields/age/1'
+              },
+              'payload': {
+                'contentTypeId': 'person',
+                'fieldId': 'age',
+                'movement': {
+                  'direction': 'beforeField',
+                  'pivot': 'fullName'
+                }
+              }
+            }
+          }
+        }
+      ]);
+    }));
+  });
+});
+

--- a/test/unit/lib/migration-steps/migration-steps-validation.spec.js
+++ b/test/unit/lib/migration-steps/migration-steps-validation.spec.js
@@ -121,6 +121,178 @@ describe('migration-steps validation', function () {
     }));
   });
 
+  describe('when doing an invalid movement', function () {
+    it('returns all validation errors', Bluebird.coroutine(function * () {
+      const steps = yield createSteps(function up (migration) {
+        const person = migration.editContentType('person', {
+          description: 'A content type for a person',
+          name: 'Person'
+        });
+
+        person.moveField('field').somewhere();
+      });
+
+      const validationErrors = stripCallsites(validateSteps(steps));
+
+      expect(validationErrors).to.eql([
+        {
+          type: 'InvalidMovement',
+          message: '"somewhere" is not a valid field movement.',
+          details: {
+            step: {
+              'type': 'field/move',
+              'meta': {
+                'contentTypeInstanceId': 'contentType/person/0',
+                'fieldInstanceId': 'fields/field/0'
+              },
+              'payload': {
+                'contentTypeId': 'person',
+                'fieldId': 'field',
+                'movement': {
+                  'direction': 'somewhere',
+                  'pivot': undefined
+                }
+              }
+            }
+          }
+        }
+      ]);
+    }));
+  });
+
+  describe('when moving a field relative to itself', function () {
+    it('returns all validation errors', Bluebird.coroutine(function * () {
+      const steps = yield createSteps(function up (migration) {
+        const person = migration.editContentType('person', {
+          description: 'A content type for a person',
+          name: 'Person'
+        });
+
+        person.moveField('name').afterField('name');
+      });
+
+      const validationErrors = stripCallsites(validateSteps(steps));
+
+      expect(validationErrors).to.eql([
+        {
+          type: 'InvalidMovement',
+          message: 'You cannot move the field "name" relative to itself.',
+          details: {
+            step: {
+              'type': 'field/move',
+              'meta': {
+                'contentTypeInstanceId': 'contentType/person/0',
+                'fieldInstanceId': 'fields/name/0'
+              },
+              'payload': {
+                'contentTypeId': 'person',
+                'fieldId': 'name',
+                'movement': {
+                  'direction': 'afterField',
+                  'pivot': 'name'
+                }
+              }
+            }
+          }
+        }
+      ]);
+    }));
+  });
+
+  describe('when doing an almost valid movement', function () {
+    it('returns all validation errors', Bluebird.coroutine(function * () {
+      const steps = yield createSteps(function up (migration) {
+        const person = migration.editContentType('person', {
+          description: 'A content type for a person',
+          name: 'Person'
+        });
+
+        person.moveField('field').toTheTp();
+      });
+
+      const validationErrors = stripCallsites(validateSteps(steps));
+
+      expect(validationErrors).to.eql([
+        {
+          type: 'InvalidMovement',
+          message: '"toTheTp" is not a valid field movement. Did you mean "toTheTop"?',
+          details: {
+            step: {
+              'type': 'field/move',
+              'meta': {
+                'contentTypeInstanceId': 'contentType/person/0',
+                'fieldInstanceId': 'fields/field/0'
+              },
+              'payload': {
+                'contentTypeId': 'person',
+                'fieldId': 'field',
+                'movement': {
+                  'direction': 'toTheTp',
+                  'pivot': undefined
+                }
+              }
+            }
+          }
+        }
+      ]);
+    }));
+  });
+
+  describe('when doing a movement with an invalid type', function () {
+    it('does not error on invalid types for toTheTop and toTheBottom', Bluebird.coroutine(function * () {
+      const steps = yield createSteps(function up (migration) {
+        const person = migration.editContentType('person', {
+          description: 'A content type for a person',
+          name: 'Person'
+        });
+
+        person.moveField('field').toTheTop(true);
+        person.moveField('field').toTheBottom('pivot-field');
+      });
+
+      const validationErrors = stripCallsites(validateSteps(steps));
+
+      expect(validationErrors).to.eql([]);
+    }));
+
+    it('returns all validation errors', Bluebird.coroutine(function * () {
+      const steps = yield createSteps(function up (migration) {
+        const person = migration.editContentType('person', {
+          description: 'A content type for a person',
+          name: 'Person'
+        });
+
+        person.moveField('field').afterField(true);
+      });
+
+      const validationErrors = stripCallsites(validateSteps(steps));
+
+      expect(validationErrors).to.eql([
+        {
+          type: 'InvalidType',
+          message: '"boolean" is not a valid type for field movement. Expected "string".',
+          details: {
+            step: {
+              'type': 'field/move',
+              'meta': {
+                'contentTypeInstanceId': 'contentType/person/0',
+                'fieldInstanceId': 'fields/field/0'
+              },
+              'payload': {
+                'contentTypeId': 'person',
+                'fieldId': 'field',
+                'movement': {
+                  'direction': 'afterField',
+                  'pivot': true
+                }
+              }
+            }
+          }
+        }
+      ]);
+    }));
+  });
+
   describe('when passing the wrong type for a prop', function () {
     it('returns all the validation errors', Bluebird.coroutine(function * () {
       const invalidFunction = function () {};


### PR DESCRIPTION
Extend the migration language with methods to move a field within a CT. Moving a field within a CT has impact in how the field of an entry of the edited content type are later displayed in Contentful Webapp (i.e. fields moved to top will be displayed on top when editing an entry and so on).

If fields are not reordered they will be displayed in the order they are added.

Plan output:


```bash
The following migration has been planned

Update Content Type food

  Create field calories
    - type: "Number"
    - name: "How many calories does it have?"
  Move field calories to the first position

  Create field sugar
    - type: "Number"
    - name: "Amount of sugar"
  Move field sugar to the last position

  Create field vegan
    - type: "Boolean"
    - name: "Vegan friendly"

  Create field producer
    - type: "Symbol"
    - name: "Food producer"
  Move field producer before field vegan

  Create field gmo
    - type: "Boolean"
    - name: "Genetically modified food"
  Move field gmo after field vegan
```