### PR TITLE
fix(examples): display field in example to an existing field

### DIFF
--- a/examples/07-display-field.js
+++ b/examples/07-display-field.js
@@ -9,5 +9,5 @@ module.exports = function (migration) {
     .type('Symbol')
     .name('what it tastes like');
 
-  food.displayField('amount');
+  food.displayField('taste');
 };


### PR DESCRIPTION
### Why this change

Because otherwise without it the example fails to run.