### PR TITLE
chore(): don't require integration config in unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "test": "npm run test-unit && npm run test-integration",
     "test-watch": "npm run test-unit -- --watch",
-    "test-integration": "NODE_ENV=test mocha 'test/integration/**/*.spec.js'",
+    "test-integration": "NODE_ENV=test mocha --require test/integration/setup.js 'test/integration/**/*.spec.js'",
     "test-unit": "NODE_ENV=test mocha 'test/unit/**/*.spec.js'",
     "lint": "eslint index.js bin/contentful-migration 'examples/**/*.js' 'test/**/*.js' 'lib/**/*.js' 'bin/**/*.js'",
     "cover": "istanbul cover _mocha 'test/unit/**/*.spec.js' 'test/integration/**/*.spec.js'",

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const requiredEnvVars = [
+  'CONTENTFUL_INTEGRATION_SOURCE_SPACE',
+  'CONTENTFUL_INTEGRATION_MANAGEMENT_TOKEN'
+];
+
+const undefinedEnvVar = (key) => typeof process.env[key] === 'undefined';
+
+if (requiredEnvVars.some(undefinedEnvVar)) {
+  throw new Error('Please define all necessary "CONTENTFUL_INTEGRATION_*" environment variables');
+}

--- a/test/setup.js
+++ b/test/setup.js
@@ -6,14 +6,3 @@ const sinonChai = require('sinon-chai');
 
 chai.use(sinonChai);
 chai.use(dirtyChai);
-
-const requiredEnvVars = [
-  'CONTENTFUL_INTEGRATION_SOURCE_SPACE',
-  'CONTENTFUL_INTEGRATION_MANAGEMENT_TOKEN'
-];
-
-const undefinedEnvVar = (key) => typeof process.env[key] === 'undefined';
-
-if (requiredEnvVars.some(undefinedEnvVar)) {
-  throw new Error('Please define all necessary "CONTENTFUL_INTEGRATION_*" environment variables');
-}


### PR DESCRIPTION
### Why this change

Because it's annoying to provide those env values even when only running the unit tests.