### PR TITLE
Change field id

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ This implies that associated content for the field will be lost.
 
 `id : string` – The ID of the field to delete.
 
+#### `changeFieldId (currentId, newId)` : void
+
+Changes the field's ID.
+
+`currentId : string` – The current ID of the field.
+`newId : string` – The new ID for the field.
+
 ### Field
 
 The field object has the same methods as the properties listed in the [`ContentType.createField`](#createfieldid--string-opts--object--field) method.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -283,6 +283,34 @@ author.createField('fullName')
 author.deleteField('fullName')
 ```
 
+## contentType.ID_MUST_BE_DIFFERENT
+When setting a new field ID to the value it already has.
+
+**Example:**
+```javascript
+author.changeFieldId('fullName', 'fullName')
+```
+
+## contentType.ID_MUST_BE_UNIQUE
+When giving a field an ID that another field on the same content type already has.
+
+**Example:**
+```javascript
+author.createField('fullName')
+  .name('Full name')
+  .type('Symbol')
+
+author.changeFieldId('firstName', 'fullName')
+```
+
+## contentType.ID_MUST_MATCH_SCHEMA
+When setting a new field ID that does not match the requirements.
+
+**Example:**
+```javascript
+author.changeFieldId('fullName', '!%#')
+```
+
 ## field.REQUIRED_PROPERTY
 Whenever a required property is missing in the definition, such as, for example, the `type` property of a field.
 
@@ -290,7 +318,6 @@ Whenever a required property is missing in the definition, such as, for example,
 ```javascript
 contentType.createField('author').name('Author')
 // .type('Symbol') is missing
-```
 
 ## field.REQUIRED_DEPENDENT_PROPERTY
 Whenever editing an element, but forgetting to set a required property, such as `items` for fields of type `Array` or `linkType` for fields of type `Link`.

--- a/examples/change-field-id.js
+++ b/examples/change-field-id.js
@@ -1,0 +1,6 @@
+module.exports = function (migration) {
+  const dog = migration.editContentType('dog');
+
+  dog.changeFieldId('goodboys', 'aDifferentId');
+  dog.editField('aDifferentId').name('ID switching is fun!');
+};

--- a/lib/migration-chunks/index.js
+++ b/lib/migration-chunks/index.js
@@ -3,11 +3,13 @@
 const _ = require('lodash');
 const sliceByContentTypeId = require('./slicers/content-type-id');
 const sliceByFieldDelete = require('./slicers/field-delete');
+const sliceByFieldIdChange = require('./slicers/field-id-change');
 
 module.exports = function migrationPlan (migrationSteps) {
   const uninterruptedSteps = sliceByContentTypeId(migrationSteps);
-  const slicedByDeleteSteps = uninterruptedSteps.map((chunk) => sliceByFieldDelete(chunk));
-  const flattened = _.flatten(slicedByDeleteSteps);
+  const slicedByDeleteSteps = _.flatten(uninterruptedSteps.map((chunk) => sliceByFieldDelete(chunk)));
+  const slicedByFieldIdChangeSteps = slicedByDeleteSteps.map((chunk) => sliceByFieldIdChange(chunk));
+  const result = _.flatten(slicedByFieldIdChangeSteps);
 
-  return flattened;
+  return result;
 };

--- a/lib/migration-chunks/slicers/field-id-change.js
+++ b/lib/migration-chunks/slicers/field-id-change.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const createPredicateSlicer = require('./predicate');
+const isFieldIdChange = (item) => item.type === 'field/rename';
+
+module.exports = createPredicateSlicer((list) => {
+  if (isFieldIdChange(list[0])) {
+    return (item) => {
+      const isSameField = list[0].payload.fieldId === item.payload.fieldId;
+      return isSameField && isFieldIdChange(item);
+    };
+  }
+  return (item) => {
+    return !isFieldIdChange(item);
+  };
+});

--- a/lib/migration-chunks/validation/errors.js
+++ b/lib/migration-chunks/validation/errors.js
@@ -51,6 +51,20 @@ module.exports = {
       PIVOT_FIELD_DELETED: (id, direction) => {
         return `You cannot move a field ${direction} the field "${id}" because it has been already deleted`;
       }
+    },
+    changeId: {
+      REFERENCE_TO_OLD_ID: (oldId, newId) => {
+        return `You cannot edit the field "${oldId}" because its ID was changed to "${newId}" earlier in the migration.`;
+      },
+      ID_ALREADY_EXISTS: (oldId, newId, ctId) => {
+        return `Cannot rename field "${oldId}" to "${newId}" because a field with this ID already exists on content type "${ctId}".`;
+      },
+      ID_MUST_BE_DIFFERENT: (fieldId) => {
+        return `The new ID for the field "${fieldId}" contains the same value as the existing ID. The new ID must be different from the old.`;
+      },
+      NO_MULTIPLE_ID_CHANGES: (oldId) => {
+        return `The ID of "${oldId}" was already changed in this migration. You cannot change the ID of a field more than once.`;
+      }
     }
   },
   contentType: {

--- a/lib/migration-chunks/validation/field.js
+++ b/lib/migration-chunks/validation/field.js
@@ -40,6 +40,10 @@ function fieldHasBeenMoved (validationContext, movementKey) {
   return validationContext.fieldMovements.has(movementKey);
 }
 
+function idHasBeenChangedBefore (validationContext, oldId) {
+  return Array.from(validationContext.fieldIdChanges.values()).includes(oldId);
+}
+
 const checks = {
   'field/create': (errors, step, validationContext) => {
     const id = fieldId(step);
@@ -56,12 +60,18 @@ const checks = {
         step
       ));
     }
+
+    if (validationContext.fieldIdChanges.has(id)) {
+      // a new field is created with the old id, so it's ok to use again
+      validationContext.fieldIdChanges.delete(id);
+    }
   },
 
   'field/update': (errors, step, validationContext) => {
     const id = fieldId(step);
     const exists = fieldExists(validationContext, id);
     const removed = fieldHasBeenRemoved(validationContext, id);
+    const changedId = validationContext.fieldIdChanges.get(id);
 
     if (!exists && removed) {
       errors.push(invalidActionError(
@@ -70,7 +80,12 @@ const checks = {
       ));
     }
 
-    if (!exists && !removed) {
+    if (changedId) {
+      errors.push(invalidActionError(
+        fieldErrors.changeId.REFERENCE_TO_OLD_ID(id, changedId),
+        step
+      ));
+    } else if (!exists && !removed) {
       errors.push(invalidActionError(
         fieldErrors.update.FIELD_DOES_NOT_EXIST(id),
         step
@@ -153,6 +168,39 @@ const checks = {
         step
       ));
     }
+  },
+
+  'field/rename': (errors, step, validationContext) => {
+    const oldId = step.payload.fieldId;
+    const newId = step.payload.props.newId;
+
+    if (idHasBeenChangedBefore(validationContext, oldId)) {
+      errors.push(invalidActionError(
+        fieldErrors.changeId.NO_MULTIPLE_ID_CHANGES(oldId),
+        step
+      ));
+    }
+
+    if (oldId === newId) {
+      errors.push(invalidActionError(
+        fieldErrors.changeId.ID_MUST_BE_DIFFERENT(oldId),
+        step
+      ));
+    } else if (fieldExists(validationContext, newId)) {
+      errors.push(invalidActionError(
+        fieldErrors.changeId.ID_ALREADY_EXISTS(
+          oldId,
+          newId,
+          step.payload.contentTypeId
+        ),
+        step
+      ));
+    }
+    // remember this field's old id, so that we can check if it is erroneously used later on
+    validationContext.fieldIdChanges.set(oldId, newId);
+
+    validationContext.fieldSet.delete(oldId);
+    validationContext.fieldSet.add(newId);
   }
 };
 
@@ -166,6 +214,7 @@ module.exports = function (chunks, contentTypes = []) {
 
   const recentlyRemoved = {};
   const recentlyMoved = {};
+  const changedFieldIds = {};
 
   for (const chunk of chunks) {
     const contentTypeId = chunk[0].payload.contentTypeId;
@@ -173,10 +222,9 @@ module.exports = function (chunks, contentTypes = []) {
     const fieldSet = contentTypeFields[contentTypeId] || new Set();
     const fieldRemovals = recentlyRemoved[contentTypeId] || new Set();
     const fieldMovements = recentlyMoved[contentTypeId] || new Set();
+    const fieldIdChanges = changedFieldIds[contentTypeId] || new Map();
+    const validationContext = { fieldSet, fieldRemovals, fieldMovements, fieldIdChanges };
 
-    const validationContext = { fieldSet, fieldRemovals, fieldMovements };
-
-    // ...
     const fieldSteps = chunk.filter((step) => step.type.startsWith('field'));
 
     for (const step of fieldSteps) {
@@ -197,6 +245,7 @@ module.exports = function (chunks, contentTypes = []) {
     contentTypeFields[contentTypeId] = fieldSet;
     recentlyRemoved[contentTypeId] = fieldRemovals;
     recentlyMoved[contentTypeId] = fieldMovements;
+    changedFieldIds[contentTypeId] = fieldIdChanges;
   }
 
   return errors;

--- a/lib/migration-payloads/index.js
+++ b/lib/migration-payloads/index.js
@@ -21,7 +21,7 @@ function buildFields (result, actions) {
       ));
     }
 
-    if (action.type === 'field/update') {
+    if (action.type === 'field/update' || action.type === 'field/rename') {
       const source = _.find(result.payload.fields, { id });
 
       Object.assign(source, props);
@@ -76,6 +76,21 @@ function builder (chunk, contentType) {
   return result;
 };
 
+function updateFieldsIdsForChanges (payload, fieldIdChanges) {
+  const updatedCt = _.cloneDeep(payload);
+  const fields = updatedCt.payload.fields;
+  if (fields.some((field) => field.newId)) {
+    fieldIdChanges[payload.meta.contentTypeId] = _.cloneDeep(payload);
+  }
+  for (const field of fields) {
+    if (field.newId) {
+      field.id = field.newId;
+      delete field.newId;
+    }
+  }
+  return updatedCt;
+}
+
 module.exports = function payloadBuilder (plan, contentTypes = []) {
   const ctPayloads = contentTypes.map((ct) => {
     return {
@@ -85,9 +100,10 @@ module.exports = function payloadBuilder (plan, contentTypes = []) {
   });
   const initialContentTypeMap = _.keyBy(ctPayloads, (ct) => ct.meta.contentTypeId);
   const contentTypeMap = {};
+  const fieldIdChanges = {};
 
   const res = [];
-  // debugger
+
   for (const chunk of plan) {
     const id = chunk[0].payload.contentTypeId;
 
@@ -115,7 +131,13 @@ module.exports = function payloadBuilder (plan, contentTypes = []) {
 
     const updatedCt = builder(chunk, _.cloneDeep(contentType));
     // Link the previous payload for validation purposes
-    if (contentType) {
+    // We need to check if there has been a fieldId change, so that
+    // the previous field id is reflected correctly in the parent.
+    // Afterwards, we can forget about the id change.
+    if (fieldIdChanges[id]) {
+      updatedCt.meta.parent = fieldIdChanges[id];
+      delete fieldIdChanges[id];
+    } else if (contentType) {
       updatedCt.meta.parent = contentType;
     }
 
@@ -124,7 +146,7 @@ module.exports = function payloadBuilder (plan, contentTypes = []) {
 
     res.push(updatedCt);
 
-    const basisForNextPayload = _.cloneDeep(updatedCt);
+    const basisForNextPayload = updateFieldsIdsForChanges(updatedCt, fieldIdChanges);
     contentTypeMap[id] = basisForNextPayload;
   }
   return res;

--- a/lib/migration-payloads/validation/errors.js
+++ b/lib/migration-payloads/validation/errors.js
@@ -39,6 +39,9 @@ const errors = {
     },
     NO_TYPE_CHANGE: (fieldId, ctId, parentFieldType, fieldType) => {
       return `Cannot change the type of field "${fieldId}" on content type "${ctId}" from "${parentFieldType}" to "${fieldType}". Field types cannot be changed.`;
+    },
+    ID_MUST_MATCH_SCHEMA: (fieldId, newId) => {
+      return `The new ID "${newId}" for the field "${fieldId}" does not match the requirements. IDs must be between 1 and 64 characters long, start with a letter, and contain only alphanumeric characters as well as underscores.`;
     }
   }
 };

--- a/lib/migration-payloads/validation/schema-validation.js
+++ b/lib/migration-payloads/validation/schema-validation.js
@@ -55,8 +55,12 @@ const itemsValid = Joi.object().keys({
 
 const fieldSchema = Joi.object().keys({
   id: Joi.string().required(),
+  newId: Joi.string()
+    .invalid(Joi.ref('id'))
+    .max(64)
+    // the empty case will be caught by joi by default, we don't want duplicate errors
+    .regex(/^$|^[a-zA-Z][a-zA-Z0-9_]*$/),
   name: Joi.string().required(),
-
   type: Joi.valid(
     'Symbol',
     'Text',
@@ -181,6 +185,24 @@ const validateFields = function (payload) {
       return {
         type: 'InvalidPayload',
         message: errorMessages.field.PROPERTY_MUST_BE_ONE_OF(prop, field.id, context.valids)
+      };
+    }
+
+    if (type === 'any.invalid' && path.includes('newId')) {
+      return {
+        type: 'InvalidPayload',
+        message: errorMessages.field.ID_MUST_BE_DIFFERENT(field.id)
+      };
+    }
+
+    const isIdSchemaError = (type) => {
+      return ['string.max', 'any.empty', 'string.regex.base'].includes(type);
+    };
+
+    if (path.includes('newId') && isIdSchemaError(type)) {
+      return {
+        type: 'InvalidPayload',
+        message: errorMessages.field.ID_MUST_MATCH_SCHEMA(field.id, field.newId)
       };
     }
   });

--- a/lib/migration-steps/action-creators.js
+++ b/lib/migration-steps/action-creators.js
@@ -80,6 +80,24 @@ const actionCreators = {
         movement
       }
     }),
+    rename: (contentTypeId, contentTypeInstanceId, fieldId, fieldInstanceId, callsite, value) => ({
+      type: 'field/rename',
+      meta: {
+        contentTypeInstanceId: `contentType/${contentTypeId}/${contentTypeInstanceId}`,
+        fieldInstanceId: `fields/${fieldId}/${fieldInstanceId}`,
+        callsite: {
+          file: callsite.getFileName(),
+          line: callsite.getLineNumber()
+        }
+      },
+      payload: {
+        contentTypeId,
+        fieldId,
+        props: {
+          'newId': value
+        }
+      }
+    }),
     delete: (contentTypeId, contentTypeInstanceId, fieldId, fieldInstanceId, callsite) => ({
       type: 'field/delete',
       meta: {

--- a/lib/migration-steps/index.js
+++ b/lib/migration-steps/index.js
@@ -118,6 +118,19 @@ class ContentType extends DispatchProxy {
 
     this.dispatch(actionCreators.field.delete(this.id, this.instanceId, id, fieldInstanceId, callsite));
   }
+
+  changeFieldId (oldId, newId) {
+    const callsite = getFirstExternalCaller();
+    const fieldInstanceId = this.fieldInstanceIds.getNew(oldId);
+    this.dispatch(actionCreators.field.rename(
+      this.id,
+      this.instanceId,
+      oldId,
+      fieldInstanceId,
+      callsite,
+      newId
+    ));
+  }
 }
 
 module.exports = Bluebird.coroutine(function * migration (migrationCreator) {

--- a/lib/migration-steps/validation.js
+++ b/lib/migration-steps/validation.js
@@ -14,6 +14,7 @@ const contentTypePropsValidations = {
 
 const fieldPropsValidations = {
   id: Joi.string().required(),
+  newId: Joi.string().required(),
   name: Joi.string().required(),
   type: Joi.string().required(),
   localized: Joi.boolean().required().strict(),

--- a/test/integration/migration.spec.js
+++ b/test/integration/migration.spec.js
@@ -6,6 +6,7 @@ const createDog = require('../../examples/01-angry-dog');
 const modifyDog = require('../../examples/02-friendly-dog');
 const longExample = require('../../examples/03-long-example');
 const invalidScript = require('../../examples/05-plan-errors');
+const idChange = require('../../examples/change-field-id');
 
 const createMigrationParser = require('../../lib/migration-parser');
 const executor = require('../../lib/executor');
@@ -102,7 +103,7 @@ describe('the migration', function () {
 
     const dogResult = yield request({
       method: 'GET',
-      url: `/content_types/dog`,
+      url: '/content_types/dog',
       headers: {
         'X-Contentful-Beta-Dev-Spaces': 1
       }
@@ -135,7 +136,7 @@ describe('the migration', function () {
 
     const dogResultAfterDelete = yield request({
       method: 'GET',
-      url: `/content_types/dog`,
+      url: '/content_types/dog',
       headers: {
         'X-Contentful-Beta-Dev-Spaces': 1
       }
@@ -149,7 +150,7 @@ describe('the migration', function () {
 
     const resultAfterModify = yield request({
       method: 'GET',
-      url: `/content_types/dog`,
+      url: '/content_types/dog',
       headers: {
         'X-Contentful-Beta-Dev-Spaces': 1
       }
@@ -171,19 +172,44 @@ describe('the migration', function () {
     ]);
   }));
 
+  it('changes field IDs', co(function * () {
+    yield migrator(idChange);
+
+    const resultAfterModify = yield request({
+      method: 'GET',
+      url: '/content_types/dog',
+      headers: {
+        'X-Contentful-Beta-Dev-Spaces': 1
+      }
+    });
+
+    expect(resultAfterModify.fields).to.eql([
+      {
+        id: 'aDifferentId',
+        name: 'ID switching is fun!',
+        type: 'Number',
+        required: false,
+        disabled: false,
+        localized: false,
+        omitted: false,
+        validations: []
+      }
+    ]);
+  }));
+
   it('works when creating and modifying lots of things', co(function * () {
     yield migrator(longExample);
 
     const person = yield request({
       method: 'GET',
-      url: `/content_types/person`,
+      url: '/content_types/person',
       headers: {
         'X-Contentful-Beta-Dev-Spaces': 1
       }
     });
     const animal = yield request({
       method: 'GET',
-      url: `/content_types/animal`,
+      url: '/content_types/animal',
       headers: {
         'X-Contentful-Beta-Dev-Spaces': 1
       }

--- a/test/unit/lib/migration-chunks/validation/field/change-id.spec.js
+++ b/test/unit/lib/migration-chunks/validation/field/change-id.spec.js
@@ -1,0 +1,261 @@
+'use strict';
+
+const { expect } = require('chai');
+const Bluebird = require('bluebird');
+
+const migrationPlan = require('../../../../../../lib/migration-chunks');
+const migrationSteps = require('../../../../../../lib/migration-steps');
+const validatePlan = require('../../../../../../lib/migration-chunks/validation');
+
+const stripCallsite = require('../../../../../helpers/strip-callsite');
+const stripCallsites = (plan) => plan.map((chunk) => chunk.map(stripCallsite));
+
+describe('chunks validation when changing field ids', () => {
+  it('returns an error when referring to a field by its old id in the same migration', Bluebird.coroutine(function * () {
+    const steps = yield migrationSteps(function up (migration) {
+      const book = migration.editContentType('book');
+      book.changeFieldId('title', 'newTitle');
+      book.editField('title').name('new Title');
+    });
+    const plan = stripCallsites(migrationPlan(steps));
+    const contentTypes = [{
+      sys: { id: 'book' },
+      fields: [{
+        id: 'title'
+      }]
+    }];
+
+    const validationErrors = validatePlan(plan, contentTypes);
+    expect(validationErrors).to.eql([
+      {
+        type: 'InvalidAction',
+        message: 'You cannot edit the field "title" because its ID was changed to "newTitle" earlier in the migration.',
+        details: {
+          step: {
+            'type': 'field/update',
+            'meta': {
+              'contentTypeInstanceId': 'contentType/book/0',
+              'fieldInstanceId': 'fields/title/1'
+            },
+            'payload': {
+              'contentTypeId': 'book',
+              'fieldId': 'title',
+              'props': {
+                'name': 'new Title'
+              }
+            }
+          }
+        }
+      }
+    ]);
+  }));
+
+  it('does not return errors when switching ids for several fields', Bluebird.coroutine(function * () {
+    const steps = yield migrationSteps(function up (migration) {
+      const book = migration.editContentType('book');
+      book.changeFieldId('title', 'newTitle');
+      migration.editContentType('movie').changeFieldId('title', 'newTitle');
+      book.editField('newTitle').name('new Title');
+      book.changeFieldId('pages', 'numberOfPages');
+    });
+    const plan = stripCallsites(migrationPlan(steps));
+    const contentTypes = [{
+      sys: { id: 'book' },
+      fields: [{
+        id: 'title'
+      }, {
+        id: 'pages'
+      }]
+    }, {
+      sys: { id: 'movie' },
+      fields: [{
+        id: 'title'
+      }]
+    }];
+
+    const validationErrors = validatePlan(plan, contentTypes);
+    expect(validationErrors).to.eql([]);
+  }));
+
+  it('does not return errors when switching the id for a field and then creating a field with the same id later on', Bluebird.coroutine(function * () {
+    const steps = yield migrationSteps(function up (migration) {
+      const book = migration.editContentType('book');
+      book.changeFieldId('title', 'newTitle');
+      book.createField('title', {
+        name: 'titulo',
+        type: 'Symbol'
+      });
+    });
+    const plan = stripCallsites(migrationPlan(steps));
+    const contentTypes = [{
+      sys: { id: 'book' },
+      fields: [{
+        id: 'title'
+      }]
+    }];
+
+    const validationErrors = validatePlan(plan, contentTypes);
+    expect(validationErrors).to.eql([]);
+  }));
+
+  it('does return an error when switching the id of a field to an already existing one', Bluebird.coroutine(function * () {
+    const steps = yield migrationSteps(function up (migration) {
+      const book = migration.editContentType('book');
+      book.changeFieldId('title', 'pages');
+    });
+    const plan = stripCallsites(migrationPlan(steps));
+    const contentTypes = [{
+      sys: { id: 'book' },
+      fields: [{
+        id: 'title'
+      }, {
+        id: 'pages'
+      }]
+    }];
+
+    const validationErrors = validatePlan(plan, contentTypes);
+    expect(validationErrors).to.eql([
+      {
+        type: 'InvalidAction',
+        message: 'Cannot rename field "title" to "pages" because a field with this ID already exists on content type "book".',
+        details: {
+          step: {
+            'type': 'field/rename',
+            'meta': {
+              'contentTypeInstanceId': 'contentType/book/0',
+              'fieldInstanceId': 'fields/title/0'
+            },
+            'payload': {
+              'contentTypeId': 'book',
+              'fieldId': 'title',
+              'props': {
+                'newId': 'pages'
+              }
+            }
+          }
+        }
+      }
+    ]);
+  }));
+
+  it('does return an error when switching the id of 2 fields to the same id', Bluebird.coroutine(function * () {
+    const steps = yield migrationSteps(function up (migration) {
+      const book = migration.editContentType('book');
+      book.changeFieldId('title', 'newTitle');
+      book.changeFieldId('pages', 'title');
+      book.changeFieldId('someThingElse', 'title');
+    });
+    const plan = stripCallsites(migrationPlan(steps));
+    const contentTypes = [{
+      sys: { id: 'book' },
+      fields: [{
+        id: 'title'
+      }, {
+        id: 'pages'
+      }, {
+        id: 'someThingElse'
+      }]
+    }];
+
+    const validationErrors = validatePlan(plan, contentTypes);
+    expect(validationErrors).to.eql([
+      {
+        type: 'InvalidAction',
+        message: 'Cannot rename field "someThingElse" to "title" because a field with this ID already exists on content type "book".',
+        details: {
+          step: {
+            'type': 'field/rename',
+            'meta': {
+              'contentTypeInstanceId': 'contentType/book/0',
+              'fieldInstanceId': 'fields/someThingElse/0'
+            },
+            'payload': {
+              'contentTypeId': 'book',
+              'fieldId': 'someThingElse',
+              'props': {
+                'newId': 'title'
+              }
+            }
+          }
+        }
+      }
+    ]);
+  }));
+
+  it('when setting a new id but it is the same as the old', Bluebird.coroutine(function * () {
+    const steps = yield migrationSteps(function up (migration) {
+      const book = migration.editContentType('book');
+      book.changeFieldId('title', 'title');
+    });
+    const plan = stripCallsites(migrationPlan(steps));
+    const contentTypes = [{
+      sys: { id: 'book' },
+      fields: [{
+        id: 'title'
+      }]
+    }];
+
+    const validationErrors = validatePlan(plan, contentTypes);
+    expect(validationErrors).to.eql([
+      {
+        type: 'InvalidAction',
+        message: 'The new ID for the field "title" contains the same value as the existing ID. The new ID must be different from the old.',
+        details: {
+          step: {
+            'type': 'field/rename',
+            'meta': {
+              'contentTypeInstanceId': 'contentType/book/0',
+              'fieldInstanceId': 'fields/title/0'
+            },
+            'payload': {
+              'contentTypeId': 'book',
+              'fieldId': 'title',
+              'props': {
+                'newId': 'title'
+              }
+            }
+          }
+        }
+      }
+    ]);
+  }));
+  it('when changing the ID of a field more than once returns an error', Bluebird.coroutine(function * () {
+    const steps = yield migrationSteps(function up (migration) {
+      const school = migration.editContentType('student');
+      school.changeFieldId('school', 'primarySchool');
+      school.changeFieldId('primarySchool', 'preSchool');
+    });
+    const plan = stripCallsites(migrationPlan(steps));
+    const contentTypes = [{
+      sys: { id: 'student' },
+      fields: [{
+        id: 'school'
+      }]
+    }];
+
+    const validationErrors = validatePlan(plan, contentTypes);
+
+    expect(validationErrors).to.eql([
+      {
+        type: 'InvalidAction',
+        message: 'The ID of "primarySchool" was already changed in this migration. You cannot change the ID of a field more than once.',
+        details: {
+          step: {
+            'type': 'field/rename',
+            'meta': {
+              'contentTypeInstanceId': 'contentType/student/0',
+              'fieldInstanceId': 'fields/primarySchool/0'
+            },
+            'payload': {
+              'contentTypeId': 'student',
+              'fieldId': 'primarySchool',
+              'props': {
+                'newId': 'preSchool'
+              }
+            }
+          }
+        }
+      }
+    ]);
+  }));
+});

--- a/test/unit/lib/migration-payloads/validation/payload-validation-id-change.spec.js
+++ b/test/unit/lib/migration-payloads/validation/payload-validation-id-change.spec.js
@@ -1,0 +1,155 @@
+'use strict';
+
+const { expect } = require('chai');
+const Bluebird = require('bluebird');
+
+const validateMigration = require('./validate-payloads');
+
+describe('payload validation', function () {
+  describe('when setting a new id but it does not fit the requirements', function () {
+    it('returns an error if too short', Bluebird.coroutine(function * () {
+      const migration = function (migration) {
+        migration
+          .editContentType('book')
+          .changeFieldId('title', '');
+      };
+
+      const existingCts = [
+        {
+          sys: {
+            version: 1,
+            id: 'book'
+          },
+          name: 'Book',
+          fields: [{
+            id: 'title',
+            name: 'Title',
+            type: 'Symbol'
+          }, {
+            id: 'pages',
+            name: 'Pages',
+            type: 'Number'
+          }]
+        }
+      ];
+
+      const errors = yield validateMigration(migration, existingCts);
+
+      expect(errors).to.eql([
+        [
+          {
+            type: 'InvalidPayload',
+            message: `The new ID "" for the field "title" does not match the requirements. IDs must be between 1 and 64 characters long, start with a letter, and contain only alphanumeric characters as well as underscores.`
+          }
+        ]
+      ]);
+    }));
+
+    it('returns an error if too long', Bluebird.coroutine(function * () {
+      const longId = Array(65).fill('a').join('');
+      const migration = function (migration) {
+        migration
+          .editContentType('book')
+          .changeFieldId('title', longId);
+      };
+
+      const existingCts = [
+        {
+          sys: {
+            version: 1,
+            id: 'book'
+          },
+          name: 'Book',
+          fields: [{
+            id: 'title',
+            name: 'Title',
+            type: 'Symbol'
+          }, {
+            id: 'pages',
+            name: 'Pages',
+            type: 'Number'
+          }]
+        }
+      ];
+
+      const errors = yield validateMigration(migration, existingCts);
+
+      expect(errors).to.eql([
+        [
+          {
+            type: 'InvalidPayload',
+            message: `The new ID "${longId}" for the field "title" does not match the requirements. IDs must be between 1 and 64 characters long, start with a letter, and contain only alphanumeric characters as well as underscores.`
+          }
+        ]
+      ]);
+    }));
+
+    it('returns an error for wrong characters', Bluebird.coroutine(function * () {
+      const migration = function (migration) {
+        migration
+          .editContentType('book')
+          .changeFieldId('title', '12#hello');
+      };
+
+      const existingCts = [
+        {
+          sys: {
+            version: 1,
+            id: 'book'
+          },
+          name: 'Book',
+          fields: [{
+            id: 'title',
+            name: 'Title',
+            type: 'Symbol'
+          }, {
+            id: 'pages',
+            name: 'Pages',
+            type: 'Number'
+          }]
+        }
+      ];
+
+      const errors = yield validateMigration(migration, existingCts);
+
+      expect(errors).to.eql([
+        [
+          {
+            type: 'InvalidPayload',
+            message: `The new ID "12#hello" for the field "title" does not match the requirements. IDs must be between 1 and 64 characters long, start with a letter, and contain only alphanumeric characters as well as underscores.`
+          }
+        ]
+      ]);
+    }));
+  });
+
+  it('does not return errors when referring to a field by its new id in the same migration', Bluebird.coroutine(function * () {
+    const migration = function (migration) {
+      const book = migration.editContentType('book');
+      book.changeFieldId('title', 'newTitle');
+      book.editField('newTitle').name('new Title');
+    };
+
+    const existingCts = [
+      {
+        sys: {
+          version: 1,
+          id: 'book'
+        },
+        name: 'Book',
+        fields: [{
+          id: 'title',
+          name: 'Title',
+          type: 'Symbol'
+        }, {
+          id: 'pages',
+          name: 'Pages',
+          type: 'Number'
+        }]
+      }
+    ];
+
+    const errors = yield validateMigration(migration, existingCts);
+    expect(errors).to.eql([[], []]);
+  }));
+});

--- a/test/unit/lib/migration-payloads/validation/validate-payloads.js
+++ b/test/unit/lib/migration-payloads/validation/validate-payloads.js
@@ -1,0 +1,15 @@
+const Bluebird = require('bluebird');
+const migrationPayloads = require('../../../../../lib/migration-payloads');
+const migrationPlan = require('../../../../../lib/migration-plan');
+const migrationChunks = require('../../../../../lib/migration-chunks');
+const migrationSteps = require('../../../../../lib/migration-steps');
+const validatePayloads = require('../../../../../lib/migration-payloads/validation');
+
+module.exports = Bluebird.coroutine(function * (migration, existingCts) {
+  const steps = yield migrationSteps(migration);
+  const chunks = migrationChunks(steps);
+  const plan = migrationPlan(chunks);
+  const payloads = migrationPayloads(plan, existingCts);
+  const errors = validatePayloads(payloads);
+  return errors;
+});

--- a/test/unit/lib/migration-steps/migration-steps.spec.js
+++ b/test/unit/lib/migration-steps/migration-steps.spec.js
@@ -588,4 +588,30 @@ describe('migration-steps', function () {
       ]);
     }));
   });
+
+  describe('when setting a new id and it is ok', function () {
+    it('returns the right steps', Bluebird.coroutine(function * () {
+      const plan = yield migration(function (migration) {
+        migration
+          .editContentType('book')
+          .changeFieldId('title', 'bookTitle');
+      });
+
+      expect(stripCallsites(plan)).to.eql([
+        {
+          type: 'field/rename',
+          meta: {
+            contentTypeInstanceId: 'contentType/book/0',
+            fieldInstanceId: 'fields/title/0'
+          },
+          payload: {
+            contentTypeId: 'book',
+            fieldId: 'title',
+            props: {
+              newId: 'bookTitle'
+            }
+          }
+        }]);
+    }));
+  });
 });


### PR DESCRIPTION
This adds a `.changeFieldId()` method to content types, allowing users to change a field's ID.

It validates and covers the cases mentioned in `validation.md`.