### PR TITLE
fix(fields): Before id change, check if field exists

### DIFF
--- a/lib/migration-chunks/validation/errors.js
+++ b/lib/migration-chunks/validation/errors.js
@@ -23,13 +23,13 @@ module.exports = {
     },
     update: {
       FIELD_ALREADY_DELETED: (id) => {
-        return `You cannot set a property on field with id "${id}" because it has already been deleted.`;
+        return `You cannot edit field "${id}" because it has already been deleted.`;
       },
       FIELD_DOES_NOT_EXIST: (id) => {
-        return `You cannot set a property on field with id "${id}" because it does not exist.`;
+        return `You cannot edit field "${id}" because it does not exist.`;
       },
       CONTENT_TYPE_DOES_NOT_EXIST: (id, ctId) => {
-        return `You cannot set a property on field with id "${id}" on content type "${ctId}" because it does not exist.`;
+        return `You cannot edit field "${id}" on content type "${ctId}" because it does not exist.`;
       }
     },
     move: {

--- a/lib/migration-chunks/validation/field.js
+++ b/lib/migration-chunks/validation/field.js
@@ -171,6 +171,8 @@ const checks = {
   },
 
   'field/rename': (errors, step, validationContext) => {
+    checks['field/update'](errors, step, validationContext);
+
     const oldId = step.payload.fieldId;
     const newId = step.payload.props.newId;
 

--- a/test/unit/lib/migration-chunks/validation/field/edit.spec.js
+++ b/test/unit/lib/migration-chunks/validation/field/edit.spec.js
@@ -30,7 +30,7 @@ describe('field editing plan validation', function () {
       expect(errors).to.eql([
         {
           type: 'InvalidAction',
-          message: 'You cannot set a property on field with id "name" because it does not exist.',
+          message: 'You cannot edit field "name" because it does not exist.',
           details: {
             step: {
               'type': 'field/update',
@@ -50,7 +50,7 @@ describe('field editing plan validation', function () {
         },
         {
           type: 'InvalidAction',
-          message: 'You cannot set a property on field with id "name" because it does not exist.',
+          message: 'You cannot edit field "name" because it does not exist.',
           details: {
             step: {
               'type': 'field/update',
@@ -95,7 +95,7 @@ describe('field editing plan validation', function () {
       expect(errors).to.eql([
         {
           type: 'InvalidAction',
-          message: 'You cannot set a property on field with id "name" because it has already been deleted.',
+          message: 'You cannot edit field "name" because it has already been deleted.',
           details: {
             step: {
               'type': 'field/update',
@@ -133,7 +133,7 @@ describe('field editing plan validation', function () {
       expect(errors).to.eql([
         {
           type: 'InvalidAction',
-          message: 'You cannot set a property on field with id "name" on content type "person" because it does not exist.',
+          message: 'You cannot edit field "name" on content type "person" because it does not exist.',
           details: {
             step: {
               'type': 'field/update',


### PR DESCRIPTION
When validating a field ID change, we should perform all the basic checks that are done on a field update as well (such as checking if the field exists at all). 
That's why the 'field/update' check error messages should be worded more generally ("edit field" instead of "set property on field") so they work for edits of all kinds.