### PR TITLE
fix: Do not allow setting of same property multiple times

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -433,3 +433,28 @@ author.createField('fullName')
     { size: 5 } // needs to be object { min, max }
   ])
 ```
+
+## DUPLICATE_PROP
+When setting the same property on a content type or field multiple times.
+
+**Example:**
+```javascript
+author.createField('fullName')
+  .name('Full name')
+  .type('Symbol')
+  .name('Name')
+```
+
+Note that steps in the migration description are grouped into what will be requests to Contentful's API. If the property changes would not end up in the same request because they are done in a later, separate step, this will not produce an error.
+
+**Example:**
+```javascript
+author.createField('fullName')
+  .name('Full name')
+  .type('Symbol')
+
+migration.deleteContentType('reader');
+
+author.editField('fullName')
+  .name('Name')
+```

--- a/lib/migration-chunks/validation/duplicate-props.js
+++ b/lib/migration-chunks/validation/duplicate-props.js
@@ -1,0 +1,63 @@
+const errorMessages = require('./errors');
+
+const isSameEntity = (step, otherStep) => {
+  return (
+    step.payload.contentTypeId === otherStep.payload.contentTypeId &&
+    step.payload.fieldId === otherStep.payload.fieldId
+  );
+};
+
+const getErrorMsgParams = (step) => {
+  const type = step.type.split('/')[0];
+  const params = {
+    field: {
+      type: 'field',
+      id: step.payload.fieldId
+    },
+    contentType: {
+      type: 'content type',
+      id: step.payload.contentTypeId
+    }
+  };
+  return params[type];
+};
+
+const getDuplicateProps = (step, chunk, stepIndex) => {
+  return Object.keys(step.payload.props).reduce((duplicateProps, prop) => {
+    const isDuplicate = chunk.slice(0, stepIndex).some((stepBefore) => {
+      return stepBefore.payload.props &&
+        isSameEntity(step, stepBefore) &&
+        stepBefore.payload.props.hasOwnProperty(prop);
+    });
+    if (isDuplicate) {
+      duplicateProps.push(prop);
+    }
+    return duplicateProps;
+  }, []);
+};
+
+const getErrorsForChunk = (chunk) => {
+  return chunk.reduce((chunkErrors, step, stepIndex) => {
+    if (step.payload.props) {
+      const duplicateProps = getDuplicateProps(step, chunk, stepIndex);
+      const errors = duplicateProps.map((duplicateProp) => {
+        const { type, id } = getErrorMsgParams(step);
+        return {
+          type: 'InvalidAction',
+          message: errorMessages.DUPLICATE_PROP(duplicateProp, type, id),
+          details: { step }
+        };
+      });
+      chunkErrors = chunkErrors.concat(errors);
+    }
+    return chunkErrors;
+  }, []);
+};
+
+
+module.exports = (chunks) => {
+  return chunks.reduce((errors, chunk) => {
+    const chunkErrors = getErrorsForChunk(chunk);
+    return errors.concat(chunkErrors);
+  }, []);
+};

--- a/lib/migration-chunks/validation/errors.js
+++ b/lib/migration-chunks/validation/errors.js
@@ -98,5 +98,8 @@ module.exports = {
         return `Content type "${id}" cannot be deleted because it has entries.`;
       }
     }
+  },
+  DUPLICATE_PROP: (prop, type, id) => {
+    return `You are setting the property "${prop}" on ${type} "${id}" more than once. Please set it only once.`;
   }
 };

--- a/lib/migration-chunks/validation/index.js
+++ b/lib/migration-chunks/validation/index.js
@@ -2,6 +2,7 @@
 
 const contentTypeValidations = require('./content-type');
 const fieldValidations = require('./field');
+const checkForDuplicatePropsErrors = require('./duplicate-props');
 
 module.exports = function (chunks, contentTypes) {
   const ctErrors = contentTypeValidations(chunks, contentTypes);
@@ -27,6 +28,7 @@ module.exports = function (chunks, contentTypes) {
   }
 
   const allCTs = contentTypes.concat(createdCTs);
+  const fieldErrors = fieldValidations(chunks, allCTs);
 
-  return fieldValidations(chunks, allCTs);
+  return fieldErrors.concat(checkForDuplicatePropsErrors(chunks));
 };

--- a/test/unit/lib/migration-chunks/validation/field/create.spec.js
+++ b/test/unit/lib/migration-chunks/validation/field/create.spec.js
@@ -63,6 +63,46 @@ describe('field creation plan validation', function () {
               }
             }
           }
+        },
+        {
+          type: 'InvalidAction',
+          message: 'You are setting the property "type" on field "name" more than once. Please set it only once.',
+          details: {
+            step: {
+              'type': 'field/update',
+              'meta': {
+                'contentTypeInstanceId': 'contentType/person/0',
+                'fieldInstanceId': 'fields/name/1'
+              },
+              'payload': {
+                'contentTypeId': 'person',
+                'fieldId': 'name',
+                'props': {
+                  'type': 'Decimal'
+                }
+              }
+            }
+          }
+        },
+        {
+          type: 'InvalidAction',
+          message: 'You are setting the property "type" on field "name" more than once. Please set it only once.',
+          details: {
+            step: {
+              'type': 'field/update',
+              'meta': {
+                'contentTypeInstanceId': 'contentType/person/0',
+                'fieldInstanceId': 'fields/name/2'
+              },
+              'payload': {
+                'contentTypeId': 'person',
+                'fieldId': 'name',
+                'props': {
+                  'type': 'Array'
+                }
+              }
+            }
+          }
         }
       ]);
     }));
@@ -120,6 +160,26 @@ describe('field creation plan validation', function () {
               'payload': {
                 'contentTypeId': 'person',
                 'fieldId': 'name'
+              }
+            }
+          }
+        },
+        {
+          type: 'InvalidAction',
+          message: 'You are setting the property "type" on field "name" more than once. Please set it only once.',
+          details: {
+            step: {
+              'type': 'field/update',
+              'meta': {
+                'contentTypeInstanceId': 'contentType/person/0',
+                'fieldInstanceId': 'fields/name/1'
+              },
+              'payload': {
+                'contentTypeId': 'person',
+                'fieldId': 'name',
+                'props': {
+                  'type': 'Decimal'
+                }
               }
             }
           }


### PR DESCRIPTION
Previously, users could set a property on the same entity multiple times. This got collapsed into the correct payload but was showing the duplicates when rendering the plan. 

This PR introduces duplicate props validation for chunks, meaning props cannot be set multiple times within the same chunk (but setting them several times in separate chunks is ok).

The validation is happening after content type and fields validation, because it needs to look at a chunk including all its steps and because it makes sense to perform those basic validations first.