### PR TITLE
Show invalid combination of validation props

### DIFF
--- a/lib/migration-payloads/validation/errors.js
+++ b/lib/migration-payloads/validation/errors.js
@@ -50,6 +50,16 @@ const errors = {
       INVALID_VALIDATION_PROPERTY: (propName) => {
         return `A field can't have "${propName}" as a validation.`;
       },
+      INVALID_VALIDATION_PROPERTY_COMBINATION: (keys) => {
+        const wrappedKeys = keys.map((key) => `"${key}"`);
+        const list = wrappedKeys.slice(0, -1);
+        const [last] = wrappedKeys.slice(-1);
+
+        const commaSeparatedKeys = list.join(', ');
+        const formattedCombination = `${commaSeparatedKeys} and ${last}`;
+
+        return `A field can't have the combination ${formattedCombination} as a validation.`;
+      },
       INVALID_VALIDATION_PARAMETER: (propName, expectedType, actualType) => {
         return `"${propName}" validation expected to be "${expectedType}", but got "${actualType}"`;
       }

--- a/lib/migration-payloads/validation/schema-validation.js
+++ b/lib/migration-payloads/validation/schema-validation.js
@@ -132,6 +132,45 @@ const validateContentType = function (payload) {
   });
 };
 
+const unknownCombinationError = function ({ path, keys }) {
+  const type = 'object.unknownCombination';
+  const message = `"${keys.join()}" is not allowed`;
+  const context = { keys };
+
+  return { message, path, type, context };
+};
+
+// Receives Array<ValidationError> with this structure:
+// [{
+//   message: '"foo" is not allowed',
+//   path: '0.validations.2.foo',
+//   type: 'object.allowUnknown',
+//   context: { child: 'foo', key: 'foo' }
+// }]
+const combineErrors = function (fieldValidationsErrors) {
+  const byItemPath = _.groupBy(fieldValidationsErrors, ({ path }) => {
+    return path.split('.').slice(0, -1).join('.');
+  });
+
+  const uniqPropErrorsByPath = _.entries(byItemPath).map(([path, itemErrors]) => {
+    const uniqErrors = _.uniqBy(itemErrors, 'context.key');
+    return [path, uniqErrors];
+  });
+
+  return uniqPropErrorsByPath.map(([path, errors]) => {
+    const keys = errors.map((error) => reach(error, 'context.key'));
+
+    // Invalid property
+    if (keys.length === 1) {
+      const [errorSample] = errors;
+      return errorSample;
+    }
+
+    // Invalid combined properties
+    return unknownCombinationError({ path, keys });
+  });
+};
+
 // Joi might return an `object.allowUnknown` error for each
 // non-matched field validation in `Joi.alternatives.try()`.
 // They are noise, execept when all error types are the same.
@@ -148,8 +187,9 @@ const cleanNoiseFromJoiErrors = function (error) {
   const isUnknownValidationsProp = fieldValidationsErrors.every(({ type }) => type === 'object.allowUnknown');
 
   if (isUnknownValidationsProp) {
-    const sampleError = fieldValidationsErrors[0];
-    return [...normalErrors, sampleError];
+    const combinedErrors = combineErrors(fieldValidationsErrors);
+
+    return [...normalErrors, ...combinedErrors];
   }
 
   const remainingFieldValidationsErrors = fieldValidationsErrors.filter(({ type }) => type !== 'object.allowUnknown');
@@ -248,6 +288,13 @@ const validateFields = function (payload) {
         return {
           type: 'InvalidPayload',
           message: errorMessages.field.validations.INVALID_VALIDATION_PROPERTY(context.key)
+        };
+      }
+
+      if (type === 'object.unknownCombination') {
+        return {
+          type: 'InvalidPayload',
+          message: errorMessages.field.validations.INVALID_VALIDATION_PROPERTY_COMBINATION(context.keys)
         };
       }
 


### PR DESCRIPTION
As mentioned in #20, currently the validation message is not very meaningful when you have an additional un-allowed property in an otherwise valid validation object.