### PR TITLE
Allow migration script to be async

### DIFF
--- a/lib/migration-steps/dispatch-proxy.js
+++ b/lib/migration-steps/dispatch-proxy.js
@@ -14,6 +14,15 @@ class DispatchProxy {
   constructor ({ dispatchUpdate }) {
     const dispatchProxy = new Proxy(this, {
       get: function (target, propertyName) {
+        // Promises are determined by duck-typing
+        // if `then` or `catch` are defined, it's treated as
+        // thenable, which needs to be resolved first.
+        // Since we return the proxy for every unknown value
+        // this breaks asynchronous migration functions.
+        if (['then', 'catch'].includes(propertyName)) {
+          return void 0;
+        }
+
         if (propertyName in target) {
           return target[propertyName];
         }

--- a/test/unit/lib/migration-steps/migration-steps.spec.js
+++ b/test/unit/lib/migration-steps/migration-steps.spec.js
@@ -634,4 +634,31 @@ describe('migration-steps', function () {
         }]);
     }));
   });
+
+  describe('when using Promises within migration scripts', function () {
+    it('returns the right steps', Bluebird.coroutine(function * () {
+      const plan = yield migration(function (migration) {
+        return Bluebird.delay(1).then(() => migration
+          .editContentType('book')
+          .changeFieldId('title', 'bookTitle')
+        );
+      });
+
+      expect(stripCallsites(plan)).to.eql([
+        {
+          type: 'field/rename',
+          meta: {
+            contentTypeInstanceId: 'contentType/book/0',
+            fieldInstanceId: 'fields/title/0'
+          },
+          payload: {
+            contentTypeId: 'book',
+            fieldId: 'title',
+            props: {
+              newId: 'bookTitle'
+            }
+          }
+        }]);
+    }));
+  });
 });


### PR DESCRIPTION
From #21, we currently didn't support Promises in the way we thought.
Thanks to @jody-zeitler for early adoption and finding this bug 🥇 