### PR TITLE
fix(payloads): Do not report errors when fields are recreated

### DIFF
--- a/lib/migration-payloads/index.js
+++ b/lib/migration-payloads/index.js
@@ -9,6 +9,14 @@ const _ = require('lodash');
 // Returns:
 // - The payload to be sent to the API
 
+function purgePreviouslyDeleted (fields, id) {
+  const fieldWithSameId = _.find(fields, { id });
+
+  if (fieldWithSameId && fieldWithSameId.deleted) {
+    _.pull(fields, fieldWithSameId);
+  }
+}
+
 function buildFields (result, actions) {
   result.payload.fields = result.payload.fields || [];
   actions.forEach((action) => {
@@ -16,6 +24,7 @@ function buildFields (result, actions) {
     const props = action.payload.props;
 
     if (action.type === 'field/create') {
+      purgePreviouslyDeleted(result.payload.fields, id);
       result.payload.fields.push(Object.assign(
         {}, { id }, props
       ));

--- a/lib/migration-payloads/validation/index.js
+++ b/lib/migration-payloads/validation/index.js
@@ -77,7 +77,8 @@ const checkIfTypeWasChanged = function (payload) {
   for (const fieldId of Object.keys(fieldsById)) {
     const parentField = parentFieldsById[fieldId];
 
-    if (parentField) {
+    // we don't care about a type change if the previous change was a deletion
+    if (parentField && !parentField.deleted) {
       const fieldType = fieldsById[fieldId].type;
       const parentFieldType = parentField.type;
 

--- a/test/unit/lib/migration-payloads/validation/payload-validation-field-deletion.spec.js
+++ b/test/unit/lib/migration-payloads/validation/payload-validation-field-deletion.spec.js
@@ -97,4 +97,35 @@ describe('payload validation (deletion)', function () {
       ]);
     }));
   });
+
+  describe('when deleting and then recreating a field', function () {
+    it('does not return any error', Bluebird.coroutine(function * () {
+      const steps = yield migrationSteps(function up (migration) {
+        const dog = migration.editContentType('dog');
+
+        dog.deleteField('owner');
+
+        dog.createField('owner')
+          .type('Symbol')
+          .name('Owner name')
+          .required(false);
+      });
+
+      const existingCts = [{
+        sys: { id: 'dog', version: 3 },
+        name: 'dog',
+        fields: [
+          { id: 'owner', name: 'owner', type: 'Symbol' }
+        ]
+      }];
+
+      const chunks = migrationChunks(steps);
+      const plan = migrationPlan(chunks);
+      const payloads = migrationPayloads(plan, existingCts);
+      const errors = validatePayloads(payloads);
+      expect(errors).to.eql([
+        [], [], []
+      ]);
+    }));
+  });
 });


### PR DESCRIPTION
Previously, we reported validation errors when a migration included deleting and then recreating a field. This was because deleted fields did not get removed from the internal state of the payload builder.

In addition, we no longer perform type change checks if we see that the parent step was a deletion.