### PR TITLE
fix(step/validations): allow empty strings as content type descriptions

### DIFF
--- a/lib/migration-steps/validation.js
+++ b/lib/migration-steps/validation.js
@@ -8,7 +8,7 @@ const validationErrors = require('./errors');
 
 const contentTypePropsValidations = {
   name: Joi.string().required(),
-  description: Joi.string().required(),
+  description: Joi.string().allow('').required(),
   displayField: Joi.string().required()
 };
 

--- a/test/unit/lib/migration-steps/migration-steps-validation.spec.js
+++ b/test/unit/lib/migration-steps/migration-steps-validation.spec.js
@@ -513,4 +513,18 @@ describe('migration-steps validation', function () {
       ]);
     }));
   });
+
+  describe('when setting an empty description for a content type', function () {
+    it('does not return any errors', Bluebird.coroutine(function * () {
+      const steps = yield createSteps(function up (migration) {
+        migration.createContentType('person', {
+          description: ''
+        });
+      });
+
+      const validationErrors = stripCallsites(validateSteps(steps));
+
+      expect(validationErrors).to.eql([]);
+    }));
+  });
 });


### PR DESCRIPTION
### Why this change

At https://github.com/contentful/migration-cli/pull/32 we partially fix the bug that rejects setting empty strings as content types descriptions. This PR allows also empty strings in steps validations.