### PR TITLE
Release pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ npm-debug.log
 /.nyc_output
 /coverage.lcov
 /built
+.vscode
+contentful-migration-cli-*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+src
+test
+typings
+.envrc
+.vscode/
+.eslintrc.js
+.travis.yml
+tsconfig.json
+tslint.json
+examples/demo.gif
+contentful-migration-cli-*.tgz

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "url": "git://github.com/contentful/migration-cli.git"
   },
   "scripts": {
-    "build": "tsc -p .",
+    "clean": "rimraf built",
+    "build": "npm run clean && tsc -p .",
+    "prepare": "npm run build",
     "test": "npm run build && npm run test-unit && npm run test-integration && npm run test-e2e && npm run lint",
     "test-watch": "npm run test-unit -- --watch",
     "test-unit": "NODE_ENV=test mocha --compilers ts-node/register 'test/unit/**/*.spec.js' 'test/unit/**/*.spec.ts'",
@@ -102,6 +104,7 @@
     "nixt": "^0.5.0",
     "nyc": "^11.2.1",
     "rewire": "^2.5.2",
+    "rimraf": "^2.6.2",
     "sinon": "^2.4.1",
     "sinon-chai": "^2.13.0",
     "source-map-support": "^0.5.0",
@@ -113,5 +116,8 @@
   },
   "bin": {
     "contentful-migration": "./bin/contentful-migration"
+  },
+  "engines": {
+    "node": ">=8.0.0"
   }
 }


### PR DESCRIPTION
In order to not distribute unnecessary stuff, we `.npmignore` a good chunk of stuff.
Note that `.DS_Store` and alike are ignored by default ([full list](https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package)).

It then wipes the `built` folder and triggers a rebuild - this is hooked to the `prepare` lifecycle, so that it gets executed after `npm install` and before `npm publish`.