### PR TITLE
render errors with more details and write errors log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ npm-debug.log
 /built
 .vscode
 contentful-migration-cli-*.tgz
+errors-*


### PR DESCRIPTION
This is a proposal to give more detail when server errors happen. It's hard to anticipate where in the error the most important info is, so this will display statusText, message, details and url. Additionally, the complete errors get written to a log. This is less pretty, but more helpful when trying to find out what actually went wrong. It will look like this:
![image](https://user-images.githubusercontent.com/9396227/33025340-fd3bd900-ce0d-11e7-9a77-c0692b03d9a8.png)
