### PR TITLE
handle undefined returned values from transform and derive

### DIFF
--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -118,7 +118,7 @@ const run = async function () {
   const migrationName = path.basename(argv.filePath, '.js')
   const errorsFile = path.join(
     process.cwd(),
-    `errors-${migrationName}-${Date.now()}.ndjson`
+    `errors-${migrationName}-${Date.now()}.log`
   )
 
   const batches = parseResult.batches

--- a/src/bin/lib/write-errors-to-log.ts
+++ b/src/bin/lib/write-errors-to-log.ts
@@ -3,19 +3,13 @@ import * as util from 'util'
 
 const appendFile = util.promisify(fs.appendFile)
 
-const writeErrorsToLog = (errors: Error | Error[], filename: string): Promise<void> => {
+const writeErrorsToLog = async (errors: Error | Error[], filename: string): Promise<void> => {
   if (!Array.isArray(errors)) {
     errors = [errors]
   }
 
-  const json = errors.map((err) => {
-    const errObj = {}
-    Object.getOwnPropertyNames(err).forEach((key) => errObj[key] = err[key])
-    return JSON.stringify(errObj)
-  })
-
-  const nljson = json.join('\n')
-  return appendFile(filename, nljson)
+  const stacks = errors.map((err) => err.stack)
+  return appendFile(filename, stacks.join('\n\n'))
 }
 
 export default writeErrorsToLog

--- a/src/lib/interfaces/request.ts
+++ b/src/lib/interfaces/request.ts
@@ -2,7 +2,9 @@ interface HttpRequest {
   method: 'PUT' | 'POST' | 'DELETE' | 'GET'
   url: string
   headers?: object
-  data?: object
+  data?: {
+    fields?: object
+  }
 }
 
 export {

--- a/test/unit/lib/intent/entry-derive.spec.ts
+++ b/test/unit/lib/intent/entry-derive.spec.ts
@@ -240,5 +240,221 @@ describe('EntryDeriveIntent', function () {
         })
       ])
     })
+
+    it('does not create a new entry and leaves the source entry untouched if it returns undefined for all locales', async function () {
+      const locales = ['de-DE', 'en-US']
+
+      const step: EntryDerive = {
+        derivedContentType: 'author',
+        from: ['authorName', 'authorTwitterHandle'],
+        toReferenceField: 'author',
+        derivedFields: ['firstName', 'lastName', 'twitterHandle'],
+        identityKey: async (fromFields: any) => fromFields.authorTwitterHandle['en-US'],
+        shouldPublish: true,
+        deriveEntryForLocale: async (inputFields: any, locale: string) => {
+          // for this entry, return undefined for all locales, thus skip it
+          if (inputFields.authorName['en-US'] === 'Immanuel Kant') {
+            return
+          }
+          const [firstName, lastName] = inputFields.authorName[locale].split(' ')
+          const twitterHandle = inputFields.authorTwitterHandle[locale]
+
+          return {
+            firstName,
+            lastName,
+            twitterHandle
+          }
+        }
+      }
+
+      const intent: EntryDeriveIntent = actionCreators.contentType.deriveLinkedEntries('entry', 0, step, fakeCallsite())
+
+      const contentTypes = [{
+        name: 'Entry',
+        sys: {
+          id: 'entry',
+          version: 1
+        },
+        fields: [
+          {
+            id: 'text',
+            type: 'Text'
+          }, {
+            id: 'authorName',
+            type: 'Symbol'
+          }, {
+            id: 'authorTwitterHandle',
+            type: 'Symbol'
+          }, {
+            id: 'author',
+            type: 'Link',
+            linkType: 'Entry'
+          }
+        ]
+      }, {
+        name: 'Author',
+        sys: {
+          id: 'author',
+          version: 1
+        },
+        fields: [
+          {
+            id: 'firstName',
+            type: 'Text'
+          }, {
+            id: 'lastName',
+            type: 'Symbol'
+          }, {
+            id: 'twitterHandle',
+            type: 'Symbol'
+          }
+        ]
+      }]
+
+      const entries = [
+        makeApiEntry({
+          id: 'doge',
+          contentTypeId: 'entry',
+          version: 1,
+          fields: {
+            text: {
+              'en-US': 'Such text, wow',
+              'de-DE': 'Solch Text, wow'
+            },
+            authorName: {
+              'en-US': 'Author McAuthorface'
+            },
+            authorTwitterHandle: {
+              'en-US': 'mcauthorface'
+            }
+          }
+        }),
+        makeApiEntry({
+          id: 'clickbait',
+          contentTypeId: 'entry',
+          version: 1,
+          fields: {
+            text: {
+              'en-US': 'You won\'t believe what happened next',
+              'de-DE': 'Du wirst nicht glauben was als nächstes passierte'
+            },
+            authorName: {
+              'en-US': 'Author McAuthorface'
+            },
+            authorTwitterHandle: {
+              'en-US': 'mcauthorface'
+            }
+          }
+        }),
+        makeApiEntry({
+          id: 'categorical-imperative',
+          contentTypeId: 'entry',
+          version: 1,
+          fields: {
+            text: {
+              'en-US': 'Act only according to that maxim whereby you can, at the same time, will that it should become a universal law',
+              'de-DE': 'Handle nur nach derjenigen Maxime, durch die du zugleich wollen kannst, dass sie ein allgemeines Gesetz werde'
+            },
+            authorName: {
+              'en-US': 'Immanuel Kant'
+            },
+            authorTwitterHandle: {
+              'en-US': 'ikant'
+            }
+          }
+        })
+      ]
+
+      const api = await runIntent(intent, contentTypes, entries, locales)
+
+      const allEntries = await api.getEntriesForContentType('entry')
+      const sourceEntries = allEntries.map((entry) => entry.toApiEntry())
+
+      const allAuthors = await api.getEntriesForContentType('author')
+      const authorEntries = allAuthors.map((entry) => entry.toApiEntry())
+
+      expect(sourceEntries).to.eql([
+        makeApiEntry({
+          id: 'doge',
+          contentTypeId: 'entry',
+          version: 3,
+          fields: {
+            text: {
+              'en-US': 'Such text, wow',
+              'de-DE': 'Solch Text, wow'
+            },
+            authorName: {
+              'en-US': 'Author McAuthorface'
+            },
+            authorTwitterHandle: {
+              'en-US': 'mcauthorface'
+            },
+            author: {
+              'en-US': { sys: { type: 'Link', linkType: 'Entry', id: 'mcauthorface' } },
+              'de-DE': { sys: { type: 'Link', linkType: 'Entry', id: 'mcauthorface' } }
+            }
+          }
+        }),
+        makeApiEntry({
+          id: 'clickbait',
+          contentTypeId: 'entry',
+          version: 3,
+          fields: {
+            text: {
+              'en-US': 'You won\'t believe what happened next',
+              'de-DE': 'Du wirst nicht glauben was als nächstes passierte'
+            },
+            authorName: {
+              'en-US': 'Author McAuthorface'
+            },
+            authorTwitterHandle: {
+              'en-US': 'mcauthorface'
+            },
+            author: {
+              'en-US': { sys: { type: 'Link', linkType: 'Entry', id: 'mcauthorface' } },
+              'de-DE': { sys: { type: 'Link', linkType: 'Entry', id: 'mcauthorface' } }
+            }
+          }
+        }),
+        // we expect the Kant entry to have been left untouched at its original version and no link field
+        makeApiEntry({
+          id: 'categorical-imperative',
+          contentTypeId: 'entry',
+          version: 1,
+          fields: {
+            text: {
+              'en-US': 'Act only according to that maxim whereby you can, at the same time, will that it should become a universal law',
+              'de-DE': 'Handle nur nach derjenigen Maxime, durch die du zugleich wollen kannst, dass sie ein allgemeines Gesetz werde'
+            },
+            authorName: {
+              'en-US': 'Immanuel Kant'
+            },
+            authorTwitterHandle: {
+              'en-US': 'ikant'
+            }
+          }
+        })
+      ])
+
+      // we expect that no author entry for Kant was created
+      expect(authorEntries).to.eql([
+        makeApiEntry({
+          id: 'mcauthorface',
+          contentTypeId: 'author',
+          version: 2,
+          fields: {
+            firstName: {
+              'en-US': 'Author'
+            },
+            lastName: {
+              'en-US': 'McAuthorface'
+            },
+            twitterHandle: {
+              'en-US': 'mcauthorface'
+            }
+          }
+        })
+      ])
+    })
   })
 })


### PR DESCRIPTION
When `undefined` is returned from the transform or derive function, we don't produce a value for that locale on the transformed/ derived entry. If the function returns `undefined` for all locales of an entry, in the case of transform, it doesn't get changed, and in the case of derive, no target entry is created and the source entry is left untouched. (This is documented already in the README)

Verbose comments on this one, I can reduce those if needed.