### PR TITLE
Fix import causing logger to crash

### DIFF
--- a/src/bin/lib/write-errors-to-log.ts
+++ b/src/bin/lib/write-errors-to-log.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs'
-import * as util from 'util'
+import * as util from 'bluebird'
 
 const appendFile = util.promisify(fs.appendFile)
 


### PR DESCRIPTION
I was getting the following error when running this from my machine, I don't think there is a package called util. I think the intention was to use bluebird (which seemed to work).

```
contentful-migration --space-id $$$ migration.js                                                                                                                                                                                                                                                                                                    /usr/local/lib/node_modules/contentful-migration-cli/built/bin/lib/write-errors-to-log.js:5                                                                                                                                                                                                                                                                               const appendFile = util.promisify(fs.appendFile);                                                                                                                                                                                                                                                                                                                                                 ^                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           TypeError: util.promisify is not a function
at Object.<anonymous> (/usr/local/lib/node_modules/contentful-migration-cli/built/bin/lib/write-errors-to-log.js:5:25)
at Module._compile (module.js:571:32)
at Object.Module._extensions..js (module.js:580:10)
at Module.load (module.js:488:32)
at tryModuleLoad (module.js:447:12)
at Function.Module._load (module.js:439:3)
at Module.require (module.js:498:17)
at require (internal/module.js:20:19)
at Object.<anonymous> (/usr/local/lib/node_modules/contentful-migration-cli/built/bin/cli.js:15:31)
at Module._compile (module.js:571:32)
at Object.Module._extensions..js (module.js:580:10)
at Module.load (module.js:488:32)
at tryModuleLoad (module.js:447:12)
at Function.Module._load (module.js:439:3)                                                                                                                                                                            at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
```