### PR TITLE
feat: make cli env aware

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "kind-of": "^5.0.2",
     "listr": "^0.12.0",
     "lodash": "^4.17.4",
-    "uuid": "^3.1.0",
     "yargs": "^8.0.2"
   },
   "devDependencies": {
@@ -112,7 +111,8 @@
     "ts-node": "^3.3.0",
     "tslint": "^5.7.0",
     "tslint-config-standard": "^6.0.1",
-    "typescript": "^2.5.3"
+    "typescript": "^2.5.3",
+    "uuid": "^3.2.1"
   },
   "bin": {
     "contentful-migration": "./bin/contentful-migration"

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -32,6 +32,10 @@ const argv = yargs
   .option('space-id', {
     alias: 's',
     describe: 'ID of the space to run the migration script on'
+  }).option('environment-id', {
+    alias: 'e',
+    describe: 'ID of the environment within the space to run the migration script on',
+    default: 'master'
   })
   .option('access-token', {
     alias: 'a',
@@ -70,10 +74,12 @@ const run = async function () {
   }
 
   const spaceId = argv.spaceId
+  const environmentId = argv.environmentId
 
   const config = {
     accessToken: argv.accessToken,
-    spaceId
+    spaceId,
+    environmentId
   }
 
   const clientConfig = Object.assign({
@@ -82,8 +88,10 @@ const run = async function () {
 
   const client = createManagementClient(clientConfig)
   const makeRequest = function (requestConfig) {
-    requestConfig.url = path.join(config.spaceId, requestConfig.url)
-    return client.rawRequest(requestConfig)
+    const config = Object.assign({}, requestConfig, {
+      url: path.join(spaceId, 'environments', environmentId, requestConfig.url)
+    })
+    return client.rawRequest(config)
   }
 
   const fetcher = new Fetcher(makeRequest)

--- a/test/helpers/client.js
+++ b/test/helpers/client.js
@@ -11,102 +11,84 @@ const config = {
   application: `contentful.migration-cli.e2e-test/${packageVersion}`
 };
 
+
 const client = createManagementClient(config);
 
-const makeRequest = function (spaceId, requestConfig) {
-  requestConfig.url = path.join(spaceId, requestConfig.url);
+const makeRequest = function (spaceId, environmentId, requestConfig) {
+  requestConfig.url = path.join(spaceId, 'environments', environmentId, requestConfig.url);
   return client.rawRequest(requestConfig);
 };
 
-const waitForJobCompletion = Bluebird.coroutine(function * (makeRequest, spaceId, jobId) {
+const waitForJobCompletion = Bluebird.coroutine(function * (makeRequest, spaceId, environmentId) {
   while (true) {
     try {
-      const devSpaceJob = yield makeRequest(spaceId, {
+      const environmentJob = yield makeRequest(spaceId, environmentId, {
         method: 'GET',
-        url: `/dev_space_jobs/${jobId}`,
-        headers: {
-          'X-Contentful-Beta-Dev-Spaces': 1
-        }
+        url: ``
       });
 
-      const status = devSpaceJob.status.value;
-
+      const status = environmentJob.sys.status.sys.id;
       if (status === 'failed') {
-        throw new Error('Could not create dev space');
+        throw new Error('Could not create dev env');
       }
 
-      if (status === 'done') {
+      if (status === 'ready') {
         return;
       }
 
       yield Bluebird.delay(1000);
     } catch (error) {
-      console.log('Space copy job failed');
+      console.log('Env job failed');
       console.log(JSON.stringify(error));
       throw error;
     }
   }
 });
 
-const createDevSpace = Bluebird.coroutine(function * (spaceId, name) {
+const createDevEnvironment = Bluebird.coroutine(function * (spaceId, environmentId) {
   try {
-    const devSpaceJob = yield makeRequest(spaceId, {
-      method: 'POST',
-      url: '/dev_space_jobs',
-      headers: {
-        'X-Contentful-Beta-Dev-Spaces': 1
-      },
+    yield makeRequest(spaceId, environmentId, {
+      method: 'PUT',
+      url: '',
       data: {
-        name
+        name: environmentId
       }
     });
 
-    const jobId = devSpaceJob.sys.id;
-
-    yield waitForJobCompletion(makeRequest, spaceId, jobId);
-
-    return devSpaceJob.devSpace.sys.id;
+    yield waitForJobCompletion(makeRequest, spaceId, environmentId);
   } catch (error) {
-    console.log('Could not initiate dev space job');
+    console.log('Could not initiate dev env job');
     console.log(JSON.stringify(error));
     throw error;
   }
+  return environmentId;
 });
 
-function getDevContentType (spaceId, id) {
-  return makeRequest(spaceId, {
+function getDevContentType (spaceId, environmentId, id) {
+  return makeRequest(spaceId, environmentId, {
     method: 'GET',
-    url: `/content_types/${id}`,
-    headers: {
-      'X-Contentful-Beta-Dev-Spaces': 1
-    }
+    url: `/content_types/${id}`
   });
 }
 
-function getEntries (spaceId, id) {
-  return makeRequest(spaceId, {
+function getEntries (spaceId, environmentId, id) {
+  return makeRequest(spaceId, environmentId, {
     method: 'GET',
-    url: `/entries?content_type=${id}`,
-    headers: {
-      'X-Contentful-Beta-Dev-Spaces': 1
-    }
+    url: `/entries?content_type=${id}`
   });
 }
 
-function deleteDevSpace (spaceId) {
-  return makeRequest(spaceId, {
+function deleteDevEnvironment (spaceId, environmentId) {
+  return makeRequest(spaceId, environmentId, {
     method: 'DELETE',
-    url: '',
-    headers: {
-      'X-Contentful-Beta-Dev-Spaces': 1
-    }
+    url: ''
   });
 }
 
 module.exports = {
   makeRequest,
-  createDevSpace,
-  deleteDevSpace,
+  createDevEnvironment,
+  deleteDevEnvironment,
   getDevContentType,
   getEntries
 };

--- a/test/integration/migration.spec.js
+++ b/test/integration/migration.spec.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const Bluebird = require('bluebird');
 const Fetcher = require('../../built/lib/fetcher').default;
-const { makeRequest, createDevSpace } = require('../helpers/client');
+const { makeRequest, createDevEnvironment, deleteDevEnvironment } = require('../helpers/client');
 const { expect } = require('chai');
 const { flatten } = require('lodash');
 const createDog = require('../../examples/01-angry-dog');
@@ -16,6 +16,9 @@ const fieldMove = require('../../examples/08-move-field');
 
 const { createMigrationParser } = require('../../built/lib/migration-parser');
 const co = Bluebird.coroutine;
+const uuid = require('uuid');
+
+const ENVIRONMENT_ID = uuid.v4();
 
 const SOURCE_TEST_SPACE = process.env.CONTENTFUL_INTEGRATION_SOURCE_SPACE;
 
@@ -27,8 +30,8 @@ describe('the migration', function () {
 
   before(co(function * () {
     this.timeout(30000);
-    const devSpaceId = yield createDevSpace(SOURCE_TEST_SPACE, 'migration test dev space');
-    request = makeRequest.bind(null, devSpaceId);
+    yield createDevEnvironment(SOURCE_TEST_SPACE, ENVIRONMENT_ID);
+    request = makeRequest.bind(null, SOURCE_TEST_SPACE, ENVIRONMENT_ID);
     const fetcher = new Fetcher(request);
     migrationParser = createMigrationParser(fetcher);
     migrator = co(function * (migration) {
@@ -42,13 +45,7 @@ describe('the migration', function () {
   }));
 
   after(co(function * () {
-    yield request({
-      method: 'DELETE',
-      url: '',
-      headers: {
-        'X-Contentful-Beta-Dev-Spaces': 1
-      }
-    });
+    yield deleteDevEnvironment(SOURCE_TEST_SPACE, ENVIRONMENT_ID);
   }));
 
 


### PR DESCRIPTION
Adds environment support to the CLI and uses them to run isolated tests.
Even if not being part of the closed beta, access to the explicit `master` environment should work just fine. Only creation and manipulation of environments is feature flagged.

**Note:**
This change may make it hard for people to contribute to our codebase, because tests use environments. That means that nobody can by default run any integration or e2e tests.
Combine that with the issue that travis won't run any of those tests for external contributors because of token security issues.

Ideally we can somehow fix the travis issue, so people at least could run the tests via a PR or push.