### PR TITLE
fix: Bump editorinterface's version

### DIFF
--- a/examples/17-change-editor-interface-for-existing-content-type.js
+++ b/examples/17-change-editor-interface-for-existing-content-type.js
@@ -1,0 +1,8 @@
+module.exports = function (migration) {
+  const blogPost = migration.editContentType('blogPost', {
+    name: 'Blog post',
+    description: 'super angry'
+  });
+
+  blogPost.changeEditorInterface('slug', 'singleLine');
+};

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -139,7 +139,7 @@ export default class Fetcher implements APIFetcher {
         // Initialize a default structure for newly created content types.
         editorInterfaces.set(id, {
           sys: {
-            version: 1
+            version: 0
           },
           controls: []
         })

--- a/src/lib/offline-api/index.ts
+++ b/src/lib/offline-api/index.ts
@@ -211,10 +211,14 @@ class OfflineAPI {
 
     // Mutate version bump
     ct.version = ct.version + 1
-
     await this.modifiedContentTypes.set(id, ct)
     await this.savedContentTypes.set(id, ct.clone())
     await this.publishedContentTypes.set(id, ct.clone())
+    
+    if (this.editorInterfaces.has(id)) {
+      const editorInterfaces = this.editorInterfaces.get(id)
+      editorInterfaces.version = editorInterfaces.version + 1
+    }
 
     for (const validator of this.contentTypeValidators) {
       if (validator.hooks.includes(ApiHook.PublishContentType)) {
@@ -222,9 +226,6 @@ class OfflineAPI {
         this.currentValidationErrorsRecorded = this.currentValidationErrorsRecorded.concat(errors)
       }
     }
-    // When publishing a contentType the version of its editor interface increases also
-    const ei = this.editorInterfaces.get(id)
-    ei.version += 1
 
     return ct
   }
@@ -279,7 +280,7 @@ class OfflineAPI {
     }
     const editorInterfaces = this.editorInterfaces.get(contentTypeId)
     this.currentRequestsRecorded.push(saveEditorInterfacesRequest(contentTypeId, editorInterfaces))
-    editorInterfaces.version = editorInterfaces.version + 1
+    editorInterfaces.version += 1
     return editorInterfaces
   }
 

--- a/src/lib/offline-api/index.ts
+++ b/src/lib/offline-api/index.ts
@@ -214,7 +214,6 @@ class OfflineAPI {
     await this.modifiedContentTypes.set(id, ct)
     await this.savedContentTypes.set(id, ct.clone())
     await this.publishedContentTypes.set(id, ct.clone())
-    
     if (this.editorInterfaces.has(id)) {
       const editorInterfaces = this.editorInterfaces.get(id)
       editorInterfaces.version = editorInterfaces.version + 1

--- a/src/lib/offline-api/index.ts
+++ b/src/lib/offline-api/index.ts
@@ -280,7 +280,7 @@ class OfflineAPI {
     }
     const editorInterfaces = this.editorInterfaces.get(contentTypeId)
     this.currentRequestsRecorded.push(saveEditorInterfacesRequest(contentTypeId, editorInterfaces))
-    editorInterfaces.version += 1
+    editorInterfaces.version = editorInterfaces.version + 1
     return editorInterfaces
   }
 

--- a/src/lib/offline-api/index.ts
+++ b/src/lib/offline-api/index.ts
@@ -222,6 +222,9 @@ class OfflineAPI {
         this.currentValidationErrorsRecorded = this.currentValidationErrorsRecorded.concat(errors)
       }
     }
+    // When publishing a contentType the version of its editor interface increases also
+    const ei = this.editorInterfaces.get(id)
+    ei.version += 1
 
     return ct
   }

--- a/test/integration/migration.spec.js
+++ b/test/integration/migration.spec.js
@@ -14,6 +14,7 @@ const fieldValidation = require('../../examples/09-validate-validations');
 const displayField = require('../../examples/07-display-field');
 const fieldMove = require('../../examples/08-move-field');
 const changeEditorInterface = require('../../examples/16-change-editor-interface');
+const changeEditorInterfaceWithExistingContentType = require('../../examples/17-change-editor-interface-for-existing-content-type');
 
 const { createMigrationParser } = require('../../built/lib/migration-parser');
 const co = Bluebird.coroutine;
@@ -46,7 +47,7 @@ describe('the migration', function () {
   }));
 
   after(co(function * () {
-    yield deleteDevEnvironment(SOURCE_TEST_SPACE, ENVIRONMENT_ID);
+     // yield deleteDevEnvironment(SOURCE_TEST_SPACE, ENVIRONMENT_ID);
   }));
 
   it('creates a content type', co(function * () {
@@ -485,6 +486,21 @@ describe('the migration', function () {
       {
         fieldId: 'slug',
         widgetId: 'slugEditor'
+      }
+    ]);
+  }));
+
+  it('changes the editor interface with an existing contentType', co(function * () {
+    yield migrator(changeEditorInterfaceWithExistingContentType);
+
+    const editorInterfaces = yield request({
+      method: 'GET',
+      url: '/content_types/blogPost/editor_interface'
+    });
+    expect(editorInterfaces.controls).to.eql([
+      {
+        fieldId: 'slug',
+        widgetId: 'singleLine'
       }
     ]);
   }));

--- a/test/integration/migration.spec.js
+++ b/test/integration/migration.spec.js
@@ -47,7 +47,7 @@ describe('the migration', function () {
   }));
 
   after(co(function * () {
-     // yield deleteDevEnvironment(SOURCE_TEST_SPACE, ENVIRONMENT_ID);
+    yield deleteDevEnvironment(SOURCE_TEST_SPACE, ENVIRONMENT_ID);
   }));
 
   it('creates a content type', co(function * () {


### PR DESCRIPTION
The version of the editor interface is increased server-side whenever it's parent content type gets published. We need to take that into consideration.
this PR fixes that.

Fixes #81

- [x] Add test